### PR TITLE
Add CumulusCI Namespace Tokens

### DIFF
--- a/force-app/main/default/flexipages/Data_Import_Batch_Record_Home.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Data_Import_Batch_Record_Home.flexipage-meta.xml
@@ -25,7 +25,7 @@
                 <identifier>force_detailPanel</identifier>
                 <visibilityRule>
                     <criteria>
-                        <leftValue>{!Record.GiftBatch__c}</leftValue>
+                        <leftValue>{!Record.%%%NAMESPACE%%%GiftBatch__c}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>false</rightValue>
                     </criteria>
@@ -98,7 +98,7 @@
                 <identifier>force_highlightsPanel</identifier>
                 <visibilityRule>
                     <criteria>
-                        <leftValue>{!Record.GiftBatch__c}</leftValue>
+                        <leftValue>{!Record.%%%NAMESPACE%%%GiftBatch__c}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>false</rightValue>
                     </criteria>
@@ -115,7 +115,7 @@
                 <identifier>flexipage_tabset</identifier>
                 <visibilityRule>
                     <criteria>
-                        <leftValue>{!Record.GiftBatch__c}</leftValue>
+                        <leftValue>{!Record.%%%NAMESPACE%%%GiftBatch__c}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>false</rightValue>
                     </criteria>
@@ -128,7 +128,7 @@
                 <identifier>GE_GiftEntryForm</identifier>
                 <visibilityRule>
                     <criteria>
-                        <leftValue>{!Record.GiftBatch__c}</leftValue>
+                        <leftValue>{!Record.%%%NAMESPACE%%%GiftBatch__c}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>true</rightValue>
                     </criteria>

--- a/force-app/main/default/layouts/Account-Household Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Account-Household Layout.layout-meta.xml
@@ -23,21 +23,21 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Formal_Greeting__c</field>
+                <field>%%%NAMESPACE%%%Formal_Greeting__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Informal_Greeting__c</field>
+                <field>%%%NAMESPACE%%%Informal_Greeting__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>HouseholdPhone__c</field>
+                <field>%%%NAMESPACE%%%HouseholdPhone__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Number_of_Household_Members__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Household_Members__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -54,7 +54,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Undeliverable_Address__c</field>
+                <field>%%%NAMESPACE%%%Undeliverable_Address__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
@@ -86,41 +86,41 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Sustainer__c</field>
+                <field>%%%NAMESPACE%%%Sustainer__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>FirstCloseDate__c</field>
+                <field>%%%NAMESPACE%%%FirstCloseDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastCloseDate__c</field>
+                <field>%%%NAMESPACE%%%LastCloseDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>AverageAmount__c</field>
+                <field>%%%NAMESPACE%%%AverageAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Best_Gift_Year__c</field>
+                <field>%%%NAMESPACE%%%Best_Gift_Year__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastOppAmount__c</field>
+                <field>%%%NAMESPACE%%%LastOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LargestAmount__c</field>
+                <field>%%%NAMESPACE%%%LargestAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>SmallestAmount__c</field>
+                <field>%%%NAMESPACE%%%SmallestAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Best_Gift_Year_Total__c</field>
+                <field>%%%NAMESPACE%%%Best_Gift_Year_Total__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -133,19 +133,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>TotalOppAmount__c</field>
+                <field>%%%NAMESPACE%%%TotalOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountLastNDays__c</field>
+                <field>%%%NAMESPACE%%%OppAmountLastNDays__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountThisYear__c</field>
+                <field>%%%NAMESPACE%%%OppAmountThisYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountLastYear__c</field>
+                <field>%%%NAMESPACE%%%OppAmountLastYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -155,19 +155,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>NumberOfClosedOpps__c</field>
+                <field>%%%NAMESPACE%%%NumberOfClosedOpps__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedLastNDays__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedLastNDays__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedThisYear__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedThisYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedLastYear__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedLastYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -184,45 +184,45 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Membership_Status__c</field>
+                <field>%%%NAMESPACE%%%Membership_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>TotalMembershipOppAmount__c</field>
+                <field>%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>MembershipEndDate__c</field>
+                <field>%%%NAMESPACE%%%MembershipEndDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipLevel__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipLevel__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>MembershipJoinDate__c</field>
+                <field>%%%NAMESPACE%%%MembershipJoinDate__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipDate__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipAmount__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipOrigin__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipOrigin__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>NumberOfMembershipOpps__c</field>
+                <field>%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Membership_Span__c</field>
+                <field>%%%NAMESPACE%%%Membership_Span__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -319,7 +319,7 @@
         <fields>Installment_Amount__c</fields>
         <fields>Total__c</fields>
         <fields>Total_Paid_Installments__c</fields>
-        <relatedList>Recurring_Donation__c.Organization__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Recurring_Donation__c.%%%NAMESPACE%%%Organization__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
@@ -328,7 +328,7 @@
         <fields>Default_Address__c</fields>
         <fields>Verified__c</fields>
         <fields>Verification_Status__c</fields>
-        <relatedList>Address__c.Household_Account__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Address__c.%%%NAMESPACE%%%Household_Account__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Account-Organization Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Account-Organization Layout.layout-meta.xml
@@ -55,7 +55,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Undeliverable_Address__c</field>
+                <field>%%%NAMESPACE%%%Undeliverable_Address__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
@@ -87,41 +87,41 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Sustainer__c</field>
+                <field>%%%NAMESPACE%%%Sustainer__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>FirstCloseDate__c</field>
+                <field>%%%NAMESPACE%%%FirstCloseDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastCloseDate__c</field>
+                <field>%%%NAMESPACE%%%LastCloseDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>AverageAmount__c</field>
+                <field>%%%NAMESPACE%%%AverageAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Best_Gift_Year__c</field>
+                <field>%%%NAMESPACE%%%Best_Gift_Year__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastOppAmount__c</field>
+                <field>%%%NAMESPACE%%%LastOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LargestAmount__c</field>
+                <field>%%%NAMESPACE%%%LargestAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>SmallestAmount__c</field>
+                <field>%%%NAMESPACE%%%SmallestAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Best_Gift_Year_Total__c</field>
+                <field>%%%NAMESPACE%%%Best_Gift_Year_Total__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -134,19 +134,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>TotalOppAmount__c</field>
+                <field>%%%NAMESPACE%%%TotalOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountLastNDays__c</field>
+                <field>%%%NAMESPACE%%%OppAmountLastNDays__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountThisYear__c</field>
+                <field>%%%NAMESPACE%%%OppAmountThisYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountLastYear__c</field>
+                <field>%%%NAMESPACE%%%OppAmountLastYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -156,19 +156,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>NumberOfClosedOpps__c</field>
+                <field>%%%NAMESPACE%%%NumberOfClosedOpps__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedLastNDays__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedLastNDays__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedThisYear__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedThisYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedLastYear__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedLastYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -185,37 +185,37 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>TotalMembershipOppAmount__c</field>
+                <field>%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>MembershipEndDate__c</field>
+                <field>%%%NAMESPACE%%%MembershipEndDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipLevel__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipLevel__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>MembershipJoinDate__c</field>
+                <field>%%%NAMESPACE%%%MembershipJoinDate__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipDate__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipAmount__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipOrigin__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipOrigin__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>NumberOfMembershipOpps__c</field>
+                <field>%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -228,13 +228,13 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Funding_Focus__c</field>
+                <field>%%%NAMESPACE%%%Funding_Focus__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grantmaker__c</field>
+                <field>%%%NAMESPACE%%%Grantmaker__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -247,45 +247,45 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Company__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Company__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Percent__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Percent__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Administrator_Name__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Administrator_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Email__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Email__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Phone__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Phone__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Info_Updated__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Info_Updated__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Annual_Employee_Max__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Annual_Employee_Max__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Amount_Max__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Amount_Max__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Amount_Min__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Amount_Min__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Request_Deadline__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Request_Deadline__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -298,7 +298,7 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Comments__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Comments__c</field>
             </layoutItems>
         </layoutColumns>
         <style>OneColumn</style>
@@ -379,7 +379,7 @@
         <fields>Status__c</fields>
         <fields>StartDate__c</fields>
         <fields>EndDate__c</fields>
-        <relatedList>Affiliation__c.Organization__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Affiliation__c.%%%NAMESPACE%%%Organization__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>New_Organization_Donation</customButtons>
@@ -398,14 +398,14 @@
         <fields>Installment_Amount__c</fields>
         <fields>Total__c</fields>
         <fields>Total_Paid_Installments__c</fields>
-        <relatedList>Recurring_Donation__c.Organization__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Recurring_Donation__c.%%%NAMESPACE%%%Organization__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
         <fields>Formula_MailingAddress__c</fields>
         <fields>Verified__c</fields>
         <fields>Verification_Status__c</fields>
-        <relatedList>Address__c.Household_Account__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Address__c.%%%NAMESPACE%%%Household_Account__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Campaign-NPSP Campaign Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Campaign-NPSP Campaign Layout.layout-meta.xml
@@ -191,7 +191,7 @@
         <fields>General_Accounting_Unit__c</fields>
         <fields>Amount__c</fields>
         <fields>Percent__c</fields>
-        <relatedList>Allocation__c.Campaign__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Campaign__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Contact-Contact Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Contact-Contact Layout.layout-meta.xml
@@ -32,7 +32,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Affiliation__c</field>
+                <field>%%%NAMESPACE%%%Primary_Affiliation__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -42,7 +42,7 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Private__c</field>
+                <field>%%%NAMESPACE%%%Private__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -72,7 +72,7 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>PreferredPhone__c</field>
+                <field>%%%NAMESPACE%%%PreferredPhone__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -84,7 +84,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>WorkPhone__c</field>
+                <field>%%%NAMESPACE%%%WorkPhone__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -98,19 +98,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Preferred_Email__c</field>
+                <field>%%%NAMESPACE%%%Preferred_Email__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>HomeEmail__c</field>
+                <field>%%%NAMESPACE%%%HomeEmail__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>WorkEmail__c</field>
+                <field>%%%NAMESPACE%%%WorkEmail__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>AlternateEmail__c</field>
+                <field>%%%NAMESPACE%%%AlternateEmail__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -135,7 +135,7 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Address_Type__c</field>
+                <field>%%%NAMESPACE%%%Primary_Address_Type__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -143,25 +143,25 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Current_Address__c</field>
+                <field>%%%NAMESPACE%%%Current_Address__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Address_Verification_Status__c</field>
+                <field>%%%NAMESPACE%%%Address_Verification_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>is_Address_Override__c</field>
+                <field>%%%NAMESPACE%%%is_Address_Override__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Undeliverable_Address__c</field>
+                <field>%%%NAMESPACE%%%Undeliverable_Address__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Secondary_Address_Type__c</field>
+                <field>%%%NAMESPACE%%%Secondary_Address_Type__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -178,7 +178,7 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Formula_HouseholdMailingAddress__c</field>
+                <field>%%%NAMESPACE%%%Formula_HouseholdMailingAddress__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns/>
@@ -192,41 +192,41 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Sustainer__c</field>
+                <field>%%%NAMESPACE%%%Sustainer__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>FirstCloseDate__c</field>
+                <field>%%%NAMESPACE%%%FirstCloseDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastCloseDate__c</field>
+                <field>%%%NAMESPACE%%%LastCloseDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>AverageAmount__c</field>
+                <field>%%%NAMESPACE%%%AverageAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Best_Gift_Year__c</field>
+                <field>%%%NAMESPACE%%%Best_Gift_Year__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastOppAmount__c</field>
+                <field>%%%NAMESPACE%%%LastOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LargestAmount__c</field>
+                <field>%%%NAMESPACE%%%LargestAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>SmallestAmount__c</field>
+                <field>%%%NAMESPACE%%%SmallestAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Best_Gift_Year_Total__c</field>
+                <field>%%%NAMESPACE%%%Best_Gift_Year_Total__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
@@ -239,19 +239,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>TotalOppAmount__c</field>
+                <field>%%%NAMESPACE%%%TotalOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountLastNDays__c</field>
+                <field>%%%NAMESPACE%%%OppAmountLastNDays__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountThisYear__c</field>
+                <field>%%%NAMESPACE%%%OppAmountThisYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountLastYear__c</field>
+                <field>%%%NAMESPACE%%%OppAmountLastYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -261,19 +261,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>NumberOfClosedOpps__c</field>
+                <field>%%%NAMESPACE%%%NumberOfClosedOpps__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedLastNDays__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedLastNDays__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedThisYear__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedThisYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppsClosedLastYear__c</field>
+                <field>%%%NAMESPACE%%%OppsClosedLastYear__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -290,69 +290,69 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Soft_Credit_Total__c</field>
+                <field>%%%NAMESPACE%%%Soft_Credit_Total__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Soft_Credit_Last_N_Days__c</field>
+                <field>%%%NAMESPACE%%%Soft_Credit_Last_N_Days__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Soft_Credit_This_Year__c</field>
+                <field>%%%NAMESPACE%%%Soft_Credit_This_Year__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Soft_Credit_Last_Year__c</field>
+                <field>%%%NAMESPACE%%%Soft_Credit_Last_Year__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Soft_Credit_Two_Years_Ago__c</field>
+                <field>%%%NAMESPACE%%%Soft_Credit_Two_Years_Ago__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Largest_Soft_Credit_Amount__c</field>
+                <field>%%%NAMESPACE%%%Largest_Soft_Credit_Amount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>First_Soft_Credit_Amount__c</field>
+                <field>%%%NAMESPACE%%%First_Soft_Credit_Amount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Last_Soft_Credit_Amount__c</field>
+                <field>%%%NAMESPACE%%%Last_Soft_Credit_Amount__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Soft_Credits__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Soft_Credits__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Soft_Credits_Last_N_Days__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Soft_Credits_Last_N_Days__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Soft_Credits_This_Year__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Soft_Credits_This_Year__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Soft_Credits_Last_Year__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Soft_Credits_Last_Year__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Soft_Credits_Two_Years_Ago__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Soft_Credits_Two_Years_Ago__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Largest_Soft_Credit_Date__c</field>
+                <field>%%%NAMESPACE%%%Largest_Soft_Credit_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>First_Soft_Credit_Date__c</field>
+                <field>%%%NAMESPACE%%%First_Soft_Credit_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Last_Soft_Credit_Date__c</field>
+                <field>%%%NAMESPACE%%%Last_Soft_Credit_Date__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -365,21 +365,21 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Total_Household_Gifts__c</field>
+                <field>%%%NAMESPACE%%%Total_Household_Gifts__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountThisYearHH__c</field>
+                <field>%%%NAMESPACE%%%OppAmountThisYearHH__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OppAmountLastYearHH__c</field>
+                <field>%%%NAMESPACE%%%OppAmountLastYearHH__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastCloseDateHH__c</field>
+                <field>%%%NAMESPACE%%%LastCloseDateHH__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -392,37 +392,37 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>MembershipEndDate__c</field>
+                <field>%%%NAMESPACE%%%MembershipEndDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipLevel__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipLevel__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipOrigin__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipOrigin__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipAmount__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipAmount__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>MembershipJoinDate__c</field>
+                <field>%%%NAMESPACE%%%MembershipJoinDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>LastMembershipDate__c</field>
+                <field>%%%NAMESPACE%%%LastMembershipDate__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>TotalMembershipOppAmount__c</field>
+                <field>%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>NumberOfMembershipOpps__c</field>
+                <field>%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -512,7 +512,7 @@
         <relatedContentItems>
             <layoutItem>
                 <behavior>Readonly</behavior>
-                <field>Primary_Affiliation__c</field>
+                <field>%%%NAMESPACE%%%Primary_Affiliation__c</field>
             </layoutItem>
         </relatedContentItems>
     </relatedContent>
@@ -522,7 +522,7 @@
         <fields>Type__c</fields>
         <fields>Relationship_Explanation__c</fields>
         <fields>Status__c</fields>
-        <relatedList>Relationship__c.Contact__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Relationship__c.%%%NAMESPACE%%%Contact__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
@@ -531,7 +531,7 @@
         <fields>Status__c</fields>
         <fields>StartDate__c</fields>
         <fields>EndDate__c</fields>
-        <relatedList>Affiliation__c.Contact__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Affiliation__c.%%%NAMESPACE%%%Contact__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>
@@ -563,7 +563,7 @@
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
-        <relatedList>Recurring_Donation__c.Contact__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Recurring_Donation__c.%%%NAMESPACE%%%Contact__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>CAMPAIGN.NAME</fields>

--- a/force-app/main/default/layouts/DataImportBatch__c-NPSP Data Import Batch Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/DataImportBatch__c-NPSP Data Import Batch Layout.layout-meta.xml
@@ -177,7 +177,7 @@
         <fields>Contact1_Lastname__c</fields>
         <fields>Account1_Name__c</fields>
         <fields>LAST_UPDATE</fields>
-        <relatedList>DataImport__c.NPSP_Data_Import_Batch__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%DataImport__c.%%%NAMESPACE%%%NPSP_Data_Import_Batch__c</relatedList>
     </relatedLists>
     <showEmailCheckbox>false</showEmailCheckbox>
     <showHighlightsPanel>false</showHighlightsPanel>

--- a/force-app/main/default/layouts/Engagement_Plan_Template__c-Engagement Plan Template Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Engagement_Plan_Template__c-Engagement Plan Template Layout.layout-meta.xml
@@ -86,7 +86,7 @@
         <fields>Send_Email__c</fields>
         <fields>Priority__c</fields>
         <fields>Type__c</fields>
-        <relatedList>Engagement_Plan_Task__c.Engagement_Plan_Template__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Engagement_Plan_Task__c.%%%NAMESPACE%%%Engagement_Plan_Template__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>Opportunity__c</fields>
@@ -97,7 +97,7 @@
         <fields>Account__c</fields>
         <fields>CREATED_DATE</fields>
         <fields>CREATEDBY_USER</fields>
-        <relatedList>Engagement_Plan__c.Engagement_Plan_Template__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Engagement_Plan__c.%%%NAMESPACE%%%Engagement_Plan_Template__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/General_Accounting_Unit__c-General Accounting Unit Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/General_Accounting_Unit__c-General Accounting Unit Layout.layout-meta.xml
@@ -145,7 +145,7 @@
         <fields>Opportunity__c</fields>
         <fields>Percent__c</fields>
         <fields>Amount__c</fields>
-        <relatedList>Allocation__c.General_Accounting_Unit__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%General_Accounting_Unit__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Opportunity-Donation Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Opportunity-Donation Layout.layout-meta.xml
@@ -19,7 +19,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Contact__c</field>
+                <field>%%%NAMESPACE%%%Primary_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -53,7 +53,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Recurring_Donation__c</field>
+                <field>%%%NAMESPACE%%%Recurring_Donation__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Required</behavior>
@@ -65,15 +65,15 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Batch__c</field>
+                <field>%%%NAMESPACE%%%Batch__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Status__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Date__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Date__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -86,25 +86,25 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Payments__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Payments__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Outstanding__c</field>
+                <field>%%%NAMESPACE%%%Amount_Outstanding__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Payments_Made__c</field>
+                <field>%%%NAMESPACE%%%Payments_Made__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Written_Off__c</field>
+                <field>%%%NAMESPACE%%%Amount_Written_Off__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Do_Not_Automatically_Create_Payment__c</field>
+                <field>%%%NAMESPACE%%%Do_Not_Automatically_Create_Payment__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -117,21 +117,21 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Employer__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Employer__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Account__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Account__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Status__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -144,53 +144,53 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Tribute_Type__c</field>
+                <field>%%%NAMESPACE%%%Tribute_Type__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Tribute_Notification_Date__c</field>
+                <field>%%%NAMESPACE%%%Tribute_Notification_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Tribute_Notification_Status__c</field>
+                <field>%%%NAMESPACE%%%Tribute_Notification_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Honoree_Contact__c</field>
+                <field>%%%NAMESPACE%%%Honoree_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Honoree_Name__c</field>
+                <field>%%%NAMESPACE%%%Honoree_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Honoree_Information__c</field>
+                <field>%%%NAMESPACE%%%Honoree_Information__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Message__c</field>
+                <field>%%%NAMESPACE%%%Notification_Message__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Preference__c</field>
+                <field>%%%NAMESPACE%%%Notification_Preference__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Contact__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Name__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Email__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Email__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Information__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Information__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -296,7 +296,7 @@
         <fields>Account.ACC_NAME</fields>
         <fields>Role_Name__c</fields>
         <fields>Amount__c</fields>
-        <relatedList>Partial_Soft_Credit__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Partial_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>Schedule_Payments</customButtons>
@@ -307,7 +307,7 @@
         <fields>Payment_Method__c</fields>
         <fields>Paid__c</fields>
         <fields>Written_Off__c</fields>
-        <relatedList>OppPayment__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%OppPayment__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>Manage_Allocations</customButtons>
@@ -316,7 +316,7 @@
         <fields>General_Accounting_Unit__c</fields>
         <fields>Amount__c</fields>
         <fields>Percent__c</fields>
-        <relatedList>Allocation__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Opportunity-Grant Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Opportunity-Grant Layout.layout-meta.xml
@@ -19,7 +19,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Contact__c</field>
+                <field>%%%NAMESPACE%%%Primary_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -62,57 +62,57 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Requested_Amount__c</field>
+                <field>%%%NAMESPACE%%%Requested_Amount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Qualified_Date__c</field>
+                <field>%%%NAMESPACE%%%Qualified_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Ask_Date__c</field>
+                <field>%%%NAMESPACE%%%Ask_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grant_Requirements_Website__c</field>
+                <field>%%%NAMESPACE%%%Grant_Requirements_Website__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grant_Contract_Number__c</field>
+                <field>%%%NAMESPACE%%%Grant_Contract_Number__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grant_Program_Area_s__c</field>
+                <field>%%%NAMESPACE%%%Grant_Program_Area_s__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Previous_Grant_Opportunity__c</field>
+                <field>%%%NAMESPACE%%%Previous_Grant_Opportunity__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grant_Contract_Date__c</field>
+                <field>%%%NAMESPACE%%%Grant_Contract_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grant_Period_Start_Date__c</field>
+                <field>%%%NAMESPACE%%%Grant_Period_Start_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grant_Period_End_Date__c</field>
+                <field>%%%NAMESPACE%%%Grant_Period_End_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Next_Grant_Deadline_Due_Date__c</field>
+                <field>%%%NAMESPACE%%%Next_Grant_Deadline_Due_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Is_Grant_Renewal__c</field>
+                <field>%%%NAMESPACE%%%Is_Grant_Renewal__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Closed_Lost_Reason__c</field>
+                <field>%%%NAMESPACE%%%Closed_Lost_Reason__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -125,25 +125,25 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Payments__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Payments__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Outstanding__c</field>
+                <field>%%%NAMESPACE%%%Amount_Outstanding__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Payments_Made__c</field>
+                <field>%%%NAMESPACE%%%Payments_Made__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Written_Off__c</field>
+                <field>%%%NAMESPACE%%%Amount_Written_Off__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Do_Not_Automatically_Create_Payment__c</field>
+                <field>%%%NAMESPACE%%%Do_Not_Automatically_Create_Payment__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -249,7 +249,7 @@
         <fields>Account.ACC_NAME</fields>
         <fields>Role_Name__c</fields>
         <fields>Amount__c</fields>
-        <relatedList>Partial_Soft_Credit__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Partial_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>Schedule_Payments</customButtons>
@@ -260,7 +260,7 @@
         <fields>Payment_Method__c</fields>
         <fields>Paid__c</fields>
         <fields>Written_Off__c</fields>
-        <relatedList>OppPayment__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%OppPayment__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
@@ -268,7 +268,7 @@
         <fields>Grant_Deadline_Due_Date__c</fields>
         <fields>Grant_Deliverable_Close_Date__c</fields>
         <fields>Grant_Deliverable_Requirements__c</fields>
-        <relatedList>Grant_Deadline__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Grant_Deadline__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
         <sortField>Grant_Deadline_Due_Date__c</sortField>
         <sortOrder>Asc</sortOrder>
     </relatedLists>
@@ -277,7 +277,7 @@
         <fields>ACCOUNT.NAME</fields>
         <fields>OPPORTUNITY.CLOSE_DATE</fields>
         <fields>OPPORTUNITY.AMOUNT</fields>
-        <relatedList>Opportunity.Previous_Grant_Opportunity__c</relatedList>
+        <relatedList>Opportunity.%%%NAMESPACE%%%Previous_Grant_Opportunity__c</relatedList>
         <sortField>OPPORTUNITY.CLOSE_DATE</sortField>
         <sortOrder>Desc</sortOrder>
     </relatedLists>
@@ -288,7 +288,7 @@
         <fields>General_Accounting_Unit__c</fields>
         <fields>Amount__c</fields>
         <fields>Percent__c</fields>
-        <relatedList>Allocation__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Opportunity-In-Kind Gift Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Opportunity-In-Kind Gift Layout.layout-meta.xml
@@ -18,7 +18,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Contact__c</field>
+                <field>%%%NAMESPACE%%%Primary_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -56,11 +56,11 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Status__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Date__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Date__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -73,19 +73,19 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Fair_Market_Value__c</field>
+                <field>%%%NAMESPACE%%%Fair_Market_Value__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>In_Kind_Donor_Declared_Value__c</field>
+                <field>%%%NAMESPACE%%%In_Kind_Donor_Declared_Value__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>In_Kind_Type__c</field>
+                <field>%%%NAMESPACE%%%In_Kind_Type__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>In_Kind_Description__c</field>
+                <field>%%%NAMESPACE%%%In_Kind_Description__c</field>
             </layoutItems>
         </layoutColumns>
         <style>OneColumn</style>
@@ -98,37 +98,37 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Tribute_Type__c</field>
+                <field>%%%NAMESPACE%%%Tribute_Type__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Honoree_Contact__c</field>
+                <field>%%%NAMESPACE%%%Honoree_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Honoree_Name__c</field>
+                <field>%%%NAMESPACE%%%Honoree_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Message__c</field>
+                <field>%%%NAMESPACE%%%Notification_Message__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Preference__c</field>
+                <field>%%%NAMESPACE%%%Notification_Preference__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Contact__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Name__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Information__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Information__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>

--- a/force-app/main/default/layouts/Opportunity-Major Gift Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Opportunity-Major Gift Layout.layout-meta.xml
@@ -19,7 +19,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Contact__c</field>
+                <field>%%%NAMESPACE%%%Primary_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -57,11 +57,11 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Status__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Date__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Date__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -74,37 +74,37 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Requested_Amount__c</field>
+                <field>%%%NAMESPACE%%%Requested_Amount__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Qualified_Date__c</field>
+                <field>%%%NAMESPACE%%%Qualified_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Ask_Date__c</field>
+                <field>%%%NAMESPACE%%%Ask_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Gift_Strategy__c</field>
+                <field>%%%NAMESPACE%%%Gift_Strategy__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Previous_Grant_Opportunity__c</field>
+                <field>%%%NAMESPACE%%%Previous_Grant_Opportunity__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Grant_Program_Area_s__c</field>
+                <field>%%%NAMESPACE%%%Grant_Program_Area_s__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Next_Grant_Deadline_Due_Date__c</field>
+                <field>%%%NAMESPACE%%%Next_Grant_Deadline_Due_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Closed_Lost_Reason__c</field>
+                <field>%%%NAMESPACE%%%Closed_Lost_Reason__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -117,25 +117,25 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Payments__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Payments__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Outstanding__c</field>
+                <field>%%%NAMESPACE%%%Amount_Outstanding__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Payments_Made__c</field>
+                <field>%%%NAMESPACE%%%Payments_Made__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Written_Off__c</field>
+                <field>%%%NAMESPACE%%%Amount_Written_Off__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Do_Not_Automatically_Create_Payment__c</field>
+                <field>%%%NAMESPACE%%%Do_Not_Automatically_Create_Payment__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -148,21 +148,21 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Employer__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Employer__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Account__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Account__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift_Status__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Matching_Gift__c</field>
+                <field>%%%NAMESPACE%%%Matching_Gift__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -175,37 +175,37 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Tribute_Type__c</field>
+                <field>%%%NAMESPACE%%%Tribute_Type__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Honoree_Contact__c</field>
+                <field>%%%NAMESPACE%%%Honoree_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Honoree_Name__c</field>
+                <field>%%%NAMESPACE%%%Honoree_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Message__c</field>
+                <field>%%%NAMESPACE%%%Notification_Message__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Preference__c</field>
+                <field>%%%NAMESPACE%%%Notification_Preference__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Contact__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Name__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Name__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Notification_Recipient_Information__c</field>
+                <field>%%%NAMESPACE%%%Notification_Recipient_Information__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -311,7 +311,7 @@
         <fields>Account.ACC_NAME</fields>
         <fields>Role_Name__c</fields>
         <fields>Amount__c</fields>
-        <relatedList>Partial_Soft_Credit__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Partial_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>Schedule_Payments</customButtons>
@@ -322,7 +322,7 @@
         <fields>Payment_Method__c</fields>
         <fields>Paid__c</fields>
         <fields>Written_Off__c</fields>
-        <relatedList>OppPayment__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%OppPayment__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
@@ -330,7 +330,7 @@
         <fields>Grant_Deadline_Due_Date__c</fields>
         <fields>Grant_Deliverable_Close_Date__c</fields>
         <fields>Grant_Deliverable_Requirements__c</fields>
-        <relatedList>Grant_Deadline__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Grant_Deadline__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
         <sortField>Grant_Deadline_Due_Date__c</sortField>
         <sortOrder>Asc</sortOrder>
     </relatedLists>
@@ -339,7 +339,7 @@
         <fields>ACCOUNT.NAME</fields>
         <fields>OPPORTUNITY.CLOSE_DATE</fields>
         <fields>OPPORTUNITY.AMOUNT</fields>
-        <relatedList>Opportunity.Previous_Grant_Opportunity__c</relatedList>
+        <relatedList>Opportunity.%%%NAMESPACE%%%Previous_Grant_Opportunity__c</relatedList>
         <sortField>OPPORTUNITY.CLOSE_DATE</sortField>
         <sortOrder>Desc</sortOrder>
     </relatedLists>
@@ -350,7 +350,7 @@
         <fields>General_Accounting_Unit__c</fields>
         <fields>Amount__c</fields>
         <fields>Percent__c</fields>
-        <relatedList>Allocation__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Opportunity-Matching Gift Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Opportunity-Matching Gift Layout.layout-meta.xml
@@ -20,7 +20,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Contact__c</field>
+                <field>%%%NAMESPACE%%%Primary_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -54,7 +54,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Recurring_Donation__c</field>
+                <field>%%%NAMESPACE%%%Recurring_Donation__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Required</behavior>
@@ -66,15 +66,15 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Batch__c</field>
+                <field>%%%NAMESPACE%%%Batch__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Status__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Date__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Date__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -87,25 +87,25 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Payments__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Payments__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Outstanding__c</field>
+                <field>%%%NAMESPACE%%%Amount_Outstanding__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Payments_Made__c</field>
+                <field>%%%NAMESPACE%%%Payments_Made__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Written_Off__c</field>
+                <field>%%%NAMESPACE%%%Amount_Written_Off__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Do_Not_Automatically_Create_Payment__c</field>
+                <field>%%%NAMESPACE%%%Do_Not_Automatically_Create_Payment__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -211,7 +211,7 @@
         <fields>Account.ACC_NAME</fields>
         <fields>Role_Name__c</fields>
         <fields>Amount__c</fields>
-        <relatedList>Partial_Soft_Credit__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Partial_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <excludeButtons>New</excludeButtons>
@@ -221,7 +221,7 @@
         <fields>OPPORTUNITY.AMOUNT</fields>
         <fields>OPPORTUNITY.CLOSE_DATE</fields>
         <fields>OPPORTUNITY.STAGE_NAME</fields>
-        <relatedList>Opportunity.Matching_Gift__c</relatedList>
+        <relatedList>Opportunity.%%%NAMESPACE%%%Matching_Gift__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>Manage_Allocations</customButtons>
@@ -230,7 +230,7 @@
         <fields>General_Accounting_Unit__c</fields>
         <fields>Amount__c</fields>
         <fields>Percent__c</fields>
-        <relatedList>Allocation__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>Schedule_Payments</customButtons>
@@ -241,7 +241,7 @@
         <fields>Payment_Method__c</fields>
         <fields>Paid__c</fields>
         <fields>Written_Off__c</fields>
-        <relatedList>OppPayment__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%OppPayment__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/layouts/Opportunity-Membership Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Opportunity-Membership Layout.layout-meta.xml
@@ -18,7 +18,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Primary_Contact__c</field>
+                <field>%%%NAMESPACE%%%Primary_Contact__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -52,7 +52,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Recurring_Donation__c</field>
+                <field>%%%NAMESPACE%%%Recurring_Donation__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Required</behavior>
@@ -64,15 +64,15 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Batch__c</field>
+                <field>%%%NAMESPACE%%%Batch__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Status__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Status__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Acknowledgment_Date__c</field>
+                <field>%%%NAMESPACE%%%Acknowledgment_Date__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -85,21 +85,21 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Membership_Start_Date__c</field>
+                <field>%%%NAMESPACE%%%Membership_Start_Date__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Membership_End_Date__c</field>
+                <field>%%%NAMESPACE%%%Membership_End_Date__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Member_Level__c</field>
+                <field>%%%NAMESPACE%%%Member_Level__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Membership_Origin__c</field>
+                <field>%%%NAMESPACE%%%Membership_Origin__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -112,25 +112,25 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Number_of_Payments__c</field>
+                <field>%%%NAMESPACE%%%Number_of_Payments__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Outstanding__c</field>
+                <field>%%%NAMESPACE%%%Amount_Outstanding__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Payments_Made__c</field>
+                <field>%%%NAMESPACE%%%Payments_Made__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>Amount_Written_Off__c</field>
+                <field>%%%NAMESPACE%%%Amount_Written_Off__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Do_Not_Automatically_Create_Payment__c</field>
+                <field>%%%NAMESPACE%%%Do_Not_Automatically_Create_Payment__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -219,7 +219,7 @@
         <fields>Account.ACC_NAME</fields>
         <fields>Role_Name__c</fields>
         <fields>Amount__c</fields>
-        <relatedList>Partial_Soft_Credit__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Partial_Soft_Credit__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>NAME</fields>
@@ -228,7 +228,7 @@
         <fields>Payment_Method__c</fields>
         <fields>Paid__c</fields>
         <fields>Written_Off__c</fields>
-        <relatedList>OppPayment__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%OppPayment__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <customButtons>Manage_Allocations</customButtons>
@@ -237,7 +237,7 @@
         <fields>General_Accounting_Unit__c</fields>
         <fields>Amount__c</fields>
         <fields>Percent__c</fields>
-        <relatedList>Allocation__c.Opportunity__c</relatedList>
+        <relatedList>%%%NAMESPACE%%%Allocation__c.%%%NAMESPACE%%%Opportunity__c</relatedList>
     </relatedLists>
     <relatedLists>
         <fields>TASK.SUBJECT</fields>

--- a/force-app/main/default/objects/Account/fields/Membership_Span__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Membership_Span__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Membership_Span__c</fullName>
     <description>The number of years that a member of this Household has had a Membership (read only).</description>
     <externalId>false</externalId>
-    <formula>year(MembershipEndDate__c ) - year(MembershipJoinDate__c)</formula>
+    <formula>year(%%%NAMESPACE%%%MembershipEndDate__c ) - year(%%%NAMESPACE%%%MembershipJoinDate__c)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>The number of years that a member of this Household has had a Membership (read only).</inlineHelpText>
     <label>Membership Span</label>

--- a/force-app/main/default/objects/Account/fields/Membership_Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Membership_Status__c.field-meta.xml
@@ -3,8 +3,8 @@
     <fullName>Membership_Status__c</fullName>
     <description>The Membership status of this Household, for example, Current, Expired, or Grace Period. The value is based on Membership End Date and Grace Period. The Default Grace Period is set in NPSP Settings, under Household Settings. This field is read only.</description>
     <externalId>false</externalId>
-    <formula>if ( MembershipEndDate__c  &lt;today(), if (MembershipEndDate__c  &gt; ( TODAY() -
-IF(NOT(ISNULL($Setup.Households_Settings__c.Membership_Grace_Period__c)), $Setup.Households_Settings__c.Membership_Grace_Period__c, 30)) , &quot;Grace Period&quot; , &quot;Expired&quot;) , if(isnull(MembershipEndDate__c ),&quot;&quot;,&quot;Current&quot;))</formula>
+    <formula>if ( %%%NAMESPACE%%%MembershipEndDate__c  &lt;today(), if (%%%NAMESPACE%%%MembershipEndDate__c  &gt; ( TODAY() -
+IF(NOT(ISNULL($Setup.%%%NAMESPACE%%%Households_Settings__c.%%%NAMESPACE%%%Membership_Grace_Period__c)), $Setup.%%%NAMESPACE%%%Households_Settings__c.%%%NAMESPACE%%%Membership_Grace_Period__c, 30)) , &quot;Grace Period&quot; , &quot;Expired&quot;) , if(isnull(%%%NAMESPACE%%%MembershipEndDate__c ),&quot;&quot;,&quot;Current&quot;))</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>The Membership status of this Household, for example, Current, Expired, or Grace Period. The value is based on Membership End Date and Grace Period. The Default Grace Period is set in NPSP Settings, under Household Settings. This field is read only.</inlineHelpText>
     <label>Membership Status</label>

--- a/force-app/main/default/objects/Contact/fields/Formula_HouseholdMailingAddress__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Formula_HouseholdMailingAddress__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Formula_HouseholdMailingAddress__c</fullName>
     <description>Formula: Clone of the Household Mailing address (also a Formula)</description>
     <externalId>false</externalId>
-    <formula>IF(Organization_Type__c == 'Household Account',
+    <formula>IF(%%%NAMESPACE%%%Organization_Type__c == 'Household Account',
 
 Account.BillingStreet &amp; BR() &amp;
 Account.BillingCity &amp; IF(ISBLANK(Account.BillingCity), "", ", ") &amp; Account.BillingState &amp; " " &amp; Account.BillingPostalCode

--- a/force-app/main/default/objects/Contact/fields/Formula_HouseholdPhone__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Formula_HouseholdPhone__c.field-meta.xml
@@ -3,8 +3,8 @@
     <fullName>Formula_HouseholdPhone__c</fullName>
     <description>Formula: Simple formula of Household Phone field.</description>
     <externalId>false</externalId>
-    <formula>IF(Organization_Type__c == 'Household Account',
-Account.HouseholdPhone__c,
+    <formula>IF(%%%NAMESPACE%%%Organization_Type__c == 'Household Account',
+Account.%%%NAMESPACE%%%HouseholdPhone__c,
 Household__r.HouseholdPhone__c)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula: Simple formula of Household Phone field.</inlineHelpText>

--- a/force-app/main/default/objects/Contact/fields/HHId__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/HHId__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>HHId__c</fullName>
     <description>Holds the Id of the Household record (either Household Account, or Household object) this Contact is currently associated with (read only).</description>
     <externalId>false</externalId>
-    <formula>if(Account.SYSTEM_AccountType__c==&apos;Household Account&apos;,CASESAFEID(AccountId),CASESAFEID(Household__c))</formula>
+    <formula>if(Account.%%%NAMESPACE%%%SYSTEM_AccountType__c==&apos;Household Account&apos;,CASESAFEID(AccountId),CASESAFEID(%%%NAMESPACE%%%Household__c))</formula>
     <inlineHelpText>Holds the Id of the Household record (either Household Account, or Household object) this Contact is currently associated with (read only).</inlineHelpText>
     <label>HHId</label>
     <required>false</required>

--- a/force-app/main/default/objects/Contact/fields/Home_Address__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Home_Address__c.field-meta.xml
@@ -4,14 +4,14 @@
     <description>Formula: Uses primary address type field to determine Home Address from Mailing or Other address.</description>
     <externalId>false</externalId>
     <formula>IF(
-  ISPICKVAL(Primary_Address_Type__c,"Home"),
+  ISPICKVAL(%%%NAMESPACE%%%Primary_Address_Type__c,"Home"),
   IF(ISBLANK(MailingStreet), "", MailingStreet &amp; ", ") &amp;
   IF(ISBLANK(MailingCity), "", MailingCity &amp; ", ")&amp;
   IF(ISBLANK(MailingState), "", MailingState &amp; " ")&amp;
   IF(ISBLANK(MailingPostalCode), "", MailingPostalCode) &amp;
   IF(ISBLANK(MailingCountry), "", ", " &amp;MailingCountry)
 ,
-IF(ISPICKVAL(Secondary_Address_Type__c,"Home"),
+IF(ISPICKVAL(%%%NAMESPACE%%%Secondary_Address_Type__c,"Home"),
   IF(ISBLANK(OtherStreet), "", OtherStreet &amp; ", ") &amp;
   IF(ISBLANK(OtherCity), "", OtherCity &amp; ", ")&amp;
   IF(ISBLANK(OtherState), "", OtherState &amp; " ")&amp;

--- a/force-app/main/default/objects/Contact/fields/LastCloseDateHH__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/LastCloseDateHH__c.field-meta.xml
@@ -3,8 +3,8 @@
     <fullName>LastCloseDateHH__c</fullName>
     <description>Formula: Last Close Date field of the related Household.</description>
     <externalId>false</externalId>
-    <formula>IF(Organization_Type__c == 'Household Account',
-Account.LastCloseDate__c,
+    <formula>IF(%%%NAMESPACE%%%Organization_Type__c == 'Household Account',
+Account.%%%NAMESPACE%%%LastCloseDate__c,
 Household__r.LastCloseDate__c)</formula>
     <label>Last Household Gift Date</label>
     <required>false</required>

--- a/force-app/main/default/objects/Contact/fields/OppAmountLastYearHH__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/OppAmountLastYearHH__c.field-meta.xml
@@ -3,8 +3,8 @@
     <fullName>OppAmountLastYearHH__c</fullName>
     <description>Formula:  Total Gifts Last Year on related Household.</description>
     <externalId>false</externalId>
-    <formula>IF(Organization_Type__c == 'Household Account',
-Account.OppAmountLastYear__c,
+    <formula>IF(%%%NAMESPACE%%%Organization_Type__c == 'Household Account',
+Account.%%%NAMESPACE%%%OppAmountLastYear__c,
 Household__r.OppAmountLastYear__c)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula:  Total Gifts Last Year on related Household.</inlineHelpText>

--- a/force-app/main/default/objects/Contact/fields/OppAmountThisYearHH__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/OppAmountThisYearHH__c.field-meta.xml
@@ -3,8 +3,8 @@
     <fullName>OppAmountThisYearHH__c</fullName>
     <description>Formula:  Total Gifts This Year on related Household.</description>
     <externalId>false</externalId>
-    <formula>IF(Organization_Type__c == 'Household Account',
-Account.OppAmountThisYear__c,
+    <formula>IF(%%%NAMESPACE%%%Organization_Type__c == 'Household Account',
+Account.%%%NAMESPACE%%%OppAmountThisYear__c,
 Household__r.OppAmountThisYear__c)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula:  Total Gifts This Year on related Household.</inlineHelpText>

--- a/force-app/main/default/objects/Contact/fields/Organization_Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Organization_Type__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Organization_Type__c</fullName>
     <description>Formula: In order of preference, the SYSTEM_AccountType field, the Account Type field, and "Organization".</description>
     <externalId>false</externalId>
-    <formula>NULLVALUE(IF( Account.SYSTEM_AccountType__c=="", TEXT(Account.Type),Account.SYSTEM_AccountType__c),"Organization" )</formula>
+    <formula>NULLVALUE(IF( Account.%%%NAMESPACE%%%SYSTEM_AccountType__c=="", TEXT(Account.Type),Account.%%%NAMESPACE%%%SYSTEM_AccountType__c),"Organization" )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula: In order of preference, the SYSTEM_AccountType field, the Account Type field, and "Organization".</inlineHelpText>
     <label>Organization Type</label>

--- a/force-app/main/default/objects/Contact/fields/Other_Address__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Other_Address__c.field-meta.xml
@@ -4,14 +4,14 @@
     <description>Formula: If the Primary Address Type is Other, the Mailing Address.  If the Secondary Address Type is Other, the Other Address.</description>
     <externalId>false</externalId>
     <formula>IF(
-  ISPICKVAL(Primary_Address_Type__c,"Other"),
+  ISPICKVAL(%%%NAMESPACE%%%Primary_Address_Type__c,"Other"),
   IF(ISBLANK(MailingStreet), "", MailingStreet &amp; ", ") &amp;
   IF(ISBLANK(MailingCity), "", MailingCity &amp; ", ")&amp;
   IF(ISBLANK(MailingState), "", MailingState &amp; " ")&amp;
   IF(ISBLANK(MailingPostalCode), "", MailingPostalCode) &amp;
   IF(ISBLANK(MailingCountry), "", ", " &amp;MailingCountry)
 ,
-IF(ISPICKVAL(Secondary_Address_Type__c,"Other"),
+IF(ISPICKVAL(%%%NAMESPACE%%%Secondary_Address_Type__c,"Other"),
   IF(ISBLANK(OtherStreet), "", OtherStreet &amp; ", ") &amp;
   IF(ISBLANK(OtherCity), "", OtherCity &amp; ", ")&amp;
   IF(ISBLANK(OtherState), "", OtherState &amp; " ")&amp;

--- a/force-app/main/default/objects/Contact/fields/Primary_Contact__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Primary_Contact__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Primary_Contact__c</fullName>
     <description>Indicates if this Contact is designated as the Primary Contact on their Account (read only).</description>
     <externalId>false</externalId>
-    <formula>Account.One2OneContact__c = Id</formula>
+    <formula>Account.One2%%%NAMESPACE%%%OneContact__c = Id</formula>
     <inlineHelpText>Indicates if this Contact is designated as the Primary Contact on their Account (read only).</inlineHelpText>
     <label>Primary Contact</label>
     <type>Checkbox</type>

--- a/force-app/main/default/objects/Contact/fields/Total_Household_Gifts__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Total_Household_Gifts__c.field-meta.xml
@@ -3,8 +3,8 @@
     <fullName>Total_Household_Gifts__c</fullName>
     <description>Formula:  Total Gifts on related Household.</description>
     <externalId>false</externalId>
-    <formula>IF(Organization_Type__c == 'Household Account',
-Account.TotalOppAmount__c,
+    <formula>IF(%%%NAMESPACE%%%Organization_Type__c == 'Household Account',
+Account.%%%NAMESPACE%%%TotalOppAmount__c,
 Household__r.TotalOppAmount__c)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula:  Total Gifts on related Household.</inlineHelpText>

--- a/force-app/main/default/objects/Contact/fields/Type_of_Account__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Type_of_Account__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Type_of_Account__c</fullName>
     <description>Formula: "Individual" or "Organization" depending on Account setting.</description>
     <externalId>false</externalId>
-    <formula>IF(Account.SYSTEMIsIndividual__c,"Individual","Organization")</formula>
+    <formula>IF(Account.%%%NAMESPACE%%%SYSTEMIsIndividual__c,"Individual","Organization")</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula: "Individual" or "Organization" depending on Account setting.</inlineHelpText>
     <label>Type of Account</label>

--- a/force-app/main/default/objects/Contact/fields/Work_Address__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Work_Address__c.field-meta.xml
@@ -4,14 +4,14 @@
     <description>Formula: If the Primary Address Type is Work, the Mailing Address.  If the Secondary Address Type is Work, the Other Address.</description>
     <externalId>false</externalId>
     <formula>IF(
-  ISPICKVAL(Primary_Address_Type__c,"Work"),
+  ISPICKVAL(%%%NAMESPACE%%%Primary_Address_Type__c,"Work"),
   IF(ISBLANK(MailingStreet), "", MailingStreet &amp; ", ") &amp;
   IF(ISBLANK(MailingCity), "", MailingCity &amp; ", ")&amp;
   IF(ISBLANK(MailingState), "", MailingState &amp; " ")&amp;
   IF(ISBLANK(MailingPostalCode), "", MailingPostalCode) &amp;
   IF(ISBLANK(MailingCountry), "", ", " &amp;MailingCountry)
 ,
-IF(ISPICKVAL(Secondary_Address_Type__c,"Work"),
+IF(ISPICKVAL(%%%NAMESPACE%%%Secondary_Address_Type__c,"Work"),
   IF(ISBLANK(OtherStreet), "", OtherStreet &amp; ", ") &amp;
   IF(ISBLANK(OtherCity), "", OtherCity &amp; ", ")&amp;
   IF(ISBLANK(OtherState), "", OtherState &amp; " ")&amp;

--- a/force-app/main/default/objects/Opportunity/fields/Amount_Outstanding__c.field-meta.xml
+++ b/force-app/main/default/objects/Opportunity/fields/Amount_Outstanding__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Amount_Outstanding__c</fullName>
     <description>Formula: The Amount of this Opportunity minus the Payment Writeoff Amount and Payment Amount Received.</description>
     <externalId>false</externalId>
-    <formula>Amount - NULLVALUE(Payments_Made__c, 0) - NULLVALUE(Amount_Written_Off__c, 0)</formula>
+    <formula>Amount - NULLVALUE(%%%NAMESPACE%%%Payments_Made__c, 0) - NULLVALUE(%%%NAMESPACE%%%Amount_Written_Off__c, 0)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula: The Amount of this Opportunity minus the Payment Writeoff Amount and Payment Amount Received.</inlineHelpText>
     <label>Remaining Balance</label>

--- a/force-app/main/default/objects/Opportunity/fields/CombinedRollupFieldset__c.field-meta.xml
+++ b/force-app/main/default/objects/Opportunity/fields/CombinedRollupFieldset__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>CombinedRollupFieldset__c</fullName>
     <description>Hidden system field, do not add to layouts.</description>
     <externalId>false</externalId>
-    <formula>TEXT(CloseDate) + ';|;'+ TEXT(Amount) + ';|;'+ TEXT(Member_Level__c) + ';|;'+ TEXT(Membership_Origin__c) + ';|;' +  Id</formula>
+    <formula>TEXT(CloseDate) + ';|;'+ TEXT(Amount) + ';|;'+ TEXT(%%%NAMESPACE%%%Member_Level__c) + ';|;'+ TEXT(%%%NAMESPACE%%%Membership_Origin__c) + ';|;' +  Id</formula>
     <inlineHelpText>Formula: Concatenated fields used during rollups to locate the most recent opportunity.</inlineHelpText>
     <label>Combined Rollup Fieldset</label>
     <required>false</required>

--- a/force-app/main/default/objects/Opportunity/fields/Is_Opp_From_Individual__c.field-meta.xml
+++ b/force-app/main/default/objects/Opportunity/fields/Is_Opp_From_Individual__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Is_Opp_From_Individual__c</fullName>
     <description>Formula: Whether or not the related Account is defined as an individual (SYSTEMIsIndividual__c)</description>
     <externalId>false</externalId>
-    <formula>IF( Account.SYSTEMIsIndividual__c, 'true', 'false' )</formula>
+    <formula>IF( Account.%%%NAMESPACE%%%SYSTEMIsIndividual__c, 'true', 'false' )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>Formula: Whether or not the related Account is defined as an individual (SYSTEMIsIndividual__c)</inlineHelpText>
     <label>Is Opp From Individual</label>

--- a/force-app/main/default/objects/Opportunity/fields/Recurring_Donation_Installment_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Opportunity/fields/Recurring_Donation_Installment_Name__c.field-meta.xml
@@ -4,12 +4,12 @@
     <description>The installment name for inclusion in Opportunity naming. Shows the installment number in parentheses for open ended Recurring Donations, or the installment number out of the total for Recurring Donations with a set number of installments.</description>
     <externalId>false</externalId>
     <formula>IF(
-ISBLANK(Recurring_Donation__c),
+ISBLANK(%%%NAMESPACE%%%Recurring_Donation__c),
 &apos;&apos;,
   IF(
     OR(ISPICKVAL(Recurring_Donation__r.Open_Ended_Status__c, &apos;Open&apos;),ISPICKVAL(Recurring_Donation__r.Open_Ended_Status__c, &apos;Closed&apos;),ISBLANK(Recurring_Donation__r.Installments__c)),
-    &apos;(&apos;&amp;TEXT(Recurring_Donation_Installment_Number__c)&amp;&apos;)&apos;,
-    &apos;(&apos;&amp;TEXT(Recurring_Donation_Installment_Number__c)&amp;&apos; &apos;&amp;$Label.oppInstallmentsOf&amp;&apos; &apos;&amp;TEXT(Recurring_Donation__r.Installments__c)&amp;&apos;)&apos;
+    &apos;(&apos;&amp;TEXT(%%%NAMESPACE%%%Recurring_Donation_Installment_Number__c)&amp;&apos;)&apos;,
+    &apos;(&apos;&amp;TEXT(%%%NAMESPACE%%%Recurring_Donation_Installment_Number__c)&amp;&apos; &apos;&amp;$Label.oppInstallmentsOf&amp;&apos; &apos;&amp;TEXT(Recurring_Donation__r.Installments__c)&amp;&apos;)&apos;
   )
 )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>

--- a/force-app/main/default/reports/NPSP_Constituent_Reports/All_Organizations.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Constituent_Reports/All_Organizations.report-meta.xml
@@ -27,7 +27,7 @@
     <description>Accounts that are not One-to-One, Individual Bucket or Household Accounts.</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value></value>

--- a/force-app/main/default/reports/NPSP_Constituent_Reports/Current_Members_Contacts.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Constituent_Reports/Current_Members_Contacts.report-meta.xml
@@ -10,31 +10,31 @@
         <field>ACCOUNT.NAME</field>
     </columns>
     <columns>
-        <field>Contact.NumberOfMembershipOpps__c</field>
+        <field>Contact.%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
     </columns>
     <columns>
-        <field>Contact.MembershipJoinDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipLevel__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipLevel__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipOrigin__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipOrigin__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Contact.TotalMembershipOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
     </columns>
     <description>Current members grouped by Membership End Month</description>
     <filter>
         <criteriaItems>
-            <column>Contact.MembershipEndDate__c</column>
+            <column>Contact.%%%NAMESPACE%%%MembershipEndDate__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterOrEqual</operator>
             <value>TODAY</value>
@@ -43,7 +43,7 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Month</dateGranularity>
-        <field>Contact.MembershipEndDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipEndDate__c</field>
         <sortOrder>Asc</sortOrder>
     </groupingsDown>
     <name>Current Members (Contacts)</name>

--- a/force-app/main/default/reports/NPSP_Constituent_Reports/Lapsed_Members_Contacts.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Constituent_Reports/Lapsed_Members_Contacts.report-meta.xml
@@ -10,31 +10,31 @@
         <field>ACCOUNT.NAME</field>
     </columns>
     <columns>
-        <field>Contact.NumberOfMembershipOpps__c</field>
+        <field>Contact.%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
     </columns>
     <columns>
-        <field>Contact.MembershipJoinDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipLevel__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipLevel__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipOrigin__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipOrigin__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Contact.TotalMembershipOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
     </columns>
     <description>Contacts whose memberships have lapsed, grouped by Membership End Date</description>
     <filter>
         <criteriaItems>
-            <column>Contact.MembershipEndDate__c</column>
+            <column>Contact.%%%NAMESPACE%%%MembershipEndDate__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>lessThan</operator>
             <value>TODAY</value>
@@ -43,7 +43,7 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Month</dateGranularity>
-        <field>Contact.MembershipEndDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipEndDate__c</field>
         <sortOrder>Asc</sortOrder>
     </groupingsDown>
     <name>Lapsed Members (Contacts)</name>

--- a/force-app/main/default/reports/NPSP_Constituent_Reports/Memberships_Over_Time.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Constituent_Reports/Memberships_Over_Time.report-meta.xml
@@ -11,7 +11,7 @@
         <chartType>LineCumulative</chartType>
         <enableHoverLabels>false</enableHoverLabels>
         <expandOthers>true</expandOthers>
-        <groupingColumn>Contact.MembershipJoinDate__c</groupingColumn>
+        <groupingColumn>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</groupingColumn>
         <location>CHART_TOP</location>
         <showAxisLabels>true</showAxisLabels>
         <showPercentage>false</showPercentage>
@@ -34,31 +34,31 @@
         <field>ACCOUNT.NAME</field>
     </columns>
     <columns>
-        <field>Contact.NumberOfMembershipOpps__c</field>
+        <field>Contact.%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
     </columns>
     <columns>
-        <field>Contact.MembershipEndDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipEndDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipLevel__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipLevel__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipOrigin__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipOrigin__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Contact.TotalMembershipOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
     </columns>
     <description>New memberships over the lifetime of your org, grouped by Membership Join Date</description>
     <filter>
         <criteriaItems>
-            <column>Contact.MembershipJoinDate__c</column>
+            <column>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value></value>
@@ -67,7 +67,7 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Month</dateGranularity>
-        <field>Contact.MembershipJoinDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</field>
         <sortOrder>Asc</sortOrder>
     </groupingsDown>
     <name>Memberships Over Time</name>

--- a/force-app/main/default/reports/NPSP_Constituent_Reports/New_Members.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Constituent_Reports/New_Members.report-meta.xml
@@ -10,34 +10,34 @@
         <field>ACCOUNT.NAME</field>
     </columns>
     <columns>
-        <field>Contact.NumberOfMembershipOpps__c</field>
+        <field>Contact.%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
     </columns>
     <columns>
-        <field>Contact.MembershipJoinDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</field>
     </columns>
     <columns>
-        <field>Contact.MembershipEndDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipEndDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipLevel__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipLevel__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipOrigin__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipOrigin__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Contact.TotalMembershipOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
     </columns>
     <description>Members who joined in the last 60 days</description>
     <filter>
         <criteriaItems>
-            <column>Contact.MembershipJoinDate__c</column>
+            <column>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>LAST_N_DAYS:60</value>

--- a/force-app/main/default/reports/NPSP_Constituent_Reports/New_Renewals.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Constituent_Reports/New_Renewals.report-meta.xml
@@ -10,40 +10,40 @@
         <field>ACCOUNT.NAME</field>
     </columns>
     <columns>
-        <field>Contact.NumberOfMembershipOpps__c</field>
+        <field>Contact.%%%NAMESPACE%%%NumberOfMembershipOpps__c</field>
     </columns>
     <columns>
-        <field>Contact.MembershipJoinDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipJoinDate__c</field>
     </columns>
     <columns>
-        <field>Contact.MembershipEndDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%MembershipEndDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipLevel__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipLevel__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipDate__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipOrigin__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipOrigin__c</field>
     </columns>
     <columns>
-        <field>Contact.LastMembershipAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastMembershipAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Contact.TotalMembershipOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalMembershipOppAmount__c</field>
     </columns>
     <description>Members who have renewed in the last 60 days</description>
     <filter>
         <criteriaItems>
-            <column>Contact.LastMembershipDate__c</column>
+            <column>Contact.%%%NAMESPACE%%%LastMembershipDate__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>LAST_N_DAYS:60</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.NumberOfMembershipOpps__c</column>
+            <column>Account.%%%NAMESPACE%%%NumberOfMembershipOpps__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>1</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Delinquent_Accounts.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Delinquent_Accounts.report-meta.xml
@@ -32,7 +32,7 @@
         <field>OppPayment__c.Payment_Method__c</field>
     </columns>
     <columns>
-        <field>Opportunity.Payments_Made__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Payments_Made__c</field>
     </columns>
     <columns>
         <field>CUST_CREATED_DATE</field>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Expected_Payments_Next_90_Days.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Expected_Payments_Next_90_Days.report-meta.xml
@@ -24,7 +24,7 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_Range_Last_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_Range_Last_Year.report-meta.xml
@@ -5,7 +5,7 @@
         <developerName>BucketField_33954624</developerName>
         <masterLabel>Total Gift Last Year Range</masterLabel>
         <nullTreatment>z</nullTreatment>
-        <sourceColumnName>Account.OppAmountLastYear__c</sourceColumnName>
+        <sourceColumnName>Account.%%%NAMESPACE%%%OppAmountLastYear__c</sourceColumnName>
         <useOther>false</useOther>
         <values>
             <sourceValues>
@@ -42,18 +42,18 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.LastCloseDate__c</field>
+        <field>Account.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <columns>
         <field>RECORDTYPE</field>
@@ -67,7 +67,7 @@
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.OppAmountLastYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_Range_Two_Years_Ago.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_Range_Two_Years_Ago.report-meta.xml
@@ -46,18 +46,18 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.LastCloseDate__c</field>
+        <field>Account.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <columns>
         <field>RECORDTYPE</field>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_by_Households_This_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_by_Households_This_Year.report-meta.xml
@@ -25,7 +25,7 @@
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Household Account</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_by_Organizations_This_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Giving_by_Organizations_This_Year.report-meta.xml
@@ -25,7 +25,7 @@
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value>Household Account</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Household_Gifts_This_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Household_Gifts_This_Year.report-meta.xml
@@ -50,7 +50,7 @@
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Household Account</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_LYBUNT_Households.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_LYBUNT_Households.report-meta.xml
@@ -8,13 +8,13 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.AverageAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -26,24 +26,24 @@
         <field>PHONE1</field>
     </columns>
     <columns>
-        <field>Account.HouseholdPhone__c</field>
+        <field>Account.%%%NAMESPACE%%%HouseholdPhone__c</field>
     </columns>
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.OppAmountLastYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Household Account</value>
@@ -55,7 +55,7 @@
         <aggregateType>Sum</aggregateType>
         <dateGranularity>Day</dateGranularity>
         <field>ACCOUNT.NAME</field>
-        <sortByName>Account.TotalOppAmount__c</sortByName>
+        <sortByName>Account.%%%NAMESPACE%%%TotalOppAmount__c</sortByName>
         <sortOrder>Desc</sortOrder>
         <sortType>Aggregate</sortType>
     </groupingsDown>
@@ -67,7 +67,7 @@
     <reportType>AccountList</reportType>
     <scope>organization</scope>
     <showDetails>true</showDetails>
-    <sortColumn>Account.TotalOppAmount__c</sortColumn>
+    <sortColumn>Account.%%%NAMESPACE%%%TotalOppAmount__c</sortColumn>
     <sortOrder>Desc</sortOrder>
     <timeFrameFilter>
         <dateColumn>CREATED_DATE</dateColumn>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_LYBUNT_Organizations.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_LYBUNT_Organizations.report-meta.xml
@@ -8,13 +8,13 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.AverageAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -26,24 +26,24 @@
         <field>PHONE1</field>
     </columns>
     <columns>
-        <field>Account.HouseholdPhone__c</field>
+        <field>Account.%%%NAMESPACE%%%HouseholdPhone__c</field>
     </columns>
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.OppAmountLastYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value>Household Account</value>
@@ -55,7 +55,7 @@
         <aggregateType>Sum</aggregateType>
         <dateGranularity>Day</dateGranularity>
         <field>ACCOUNT.NAME</field>
-        <sortByName>Account.TotalOppAmount__c</sortByName>
+        <sortByName>Account.%%%NAMESPACE%%%TotalOppAmount__c</sortByName>
         <sortOrder>Desc</sortOrder>
         <sortType>Aggregate</sortType>
     </groupingsDown>
@@ -67,7 +67,7 @@
     <reportType>AccountList</reportType>
     <scope>organization</scope>
     <showDetails>true</showDetails>
-    <sortColumn>Account.TotalOppAmount__c</sortColumn>
+    <sortColumn>Account.%%%NAMESPACE%%%TotalOppAmount__c</sortColumn>
     <sortOrder>Desc</sortOrder>
     <timeFrameFilter>
         <dateColumn>CREATED_DATE</dateColumn>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Opportunity_Pipeline_Month_Stage.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Opportunity_Pipeline_Month_Stage.report-meta.xml
@@ -45,7 +45,7 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <description>Dashboard Report - Do Not Edit</description>
     <filter>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Opportunity_Pipeline_by_Campaign.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Opportunity_Pipeline_by_Campaign.report-meta.xml
@@ -44,7 +44,7 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <columns>
         <field>CLOSE_DATE</field>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Opportunity_Pipeline_by_Stage.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Opportunity_Pipeline_by_Stage.report-meta.xml
@@ -41,7 +41,7 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <columns>
         <field>CLOSE_DATE</field>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Organization_Gifts_This_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Organization_Gifts_This_Year.report-meta.xml
@@ -50,7 +50,7 @@
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value>Household Account</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Overdue_Payments.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_Overdue_Payments.report-meta.xml
@@ -32,7 +32,7 @@
         <field>OppPayment__c.Payment_Method__c</field>
     </columns>
     <columns>
-        <field>Opportunity.Payments_Made__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Payments_Made__c</field>
     </columns>
     <columns>
         <field>CUST_CREATED_DATE</field>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_SYBUNT_Households.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_SYBUNT_Households.report-meta.xml
@@ -8,13 +8,13 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.AverageAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -26,24 +26,24 @@
         <field>PHONE1</field>
     </columns>
     <columns>
-        <field>Account.HouseholdPhone__c</field>
+        <field>Account.%%%NAMESPACE%%%HouseholdPhone__c</field>
     </columns>
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.TotalOppAmount__c</column>
+            <column>Account.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Household Account</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_SYBUNT_Organizations.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/DASH_SYBUNT_Organizations.report-meta.xml
@@ -8,13 +8,13 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.AverageAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -26,24 +26,24 @@
         <field>PHONE1</field>
     </columns>
     <columns>
-        <field>Account.HouseholdPhone__c</field>
+        <field>Account.%%%NAMESPACE%%%HouseholdPhone__c</field>
     </columns>
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.TotalOppAmount__c</column>
+            <column>Account.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value>Household Account</value>

--- a/force-app/main/default/reports/NPSP_Dashboard_Reports/Giving_Range_This_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Dashboard_Reports/Giving_Range_This_Year.report-meta.xml
@@ -5,7 +5,7 @@
         <developerName>BucketField_33954624</developerName>
         <masterLabel>Total Gift This Year Range</masterLabel>
         <nullTreatment>z</nullTreatment>
-        <sourceColumnName>Account.OppAmountThisYear__c</sourceColumnName>
+        <sourceColumnName>Account.%%%NAMESPACE%%%OppAmountThisYear__c</sourceColumnName>
         <useOther>false</useOther>
         <values>
             <sourceValues>
@@ -42,14 +42,14 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.LastCloseDate__c</field>
+        <field>Account.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <columns>
         <field>RECORDTYPE</field>
@@ -63,7 +63,7 @@
     <description>Dashboard Report - Do Not Edit</description>
     <filter>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Account_LYBUNT.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Account_LYBUNT.report-meta.xml
@@ -7,13 +7,13 @@
         <field>Account.One2OneContact__c</field>
     </columns>
     <columns>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.AverageAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -25,18 +25,18 @@
         <field>PHONE1</field>
     </columns>
     <columns>
-        <field>Account.HouseholdPhone__c</field>
+        <field>Account.%%%NAMESPACE%%%HouseholdPhone__c</field>
     </columns>
     <description>Accounts that donated last year but unfortunately not this year (LYBUNT)</description>
     <filter>
         <criteriaItems>
-            <column>Account.OppAmountLastYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Account_SYBUNT.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Account_SYBUNT.report-meta.xml
@@ -7,13 +7,13 @@
         <field>Account.One2OneContact__c</field>
     </columns>
     <columns>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.AverageAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -25,18 +25,18 @@
         <field>PHONE1</field>
     </columns>
     <columns>
-        <field>Account.HouseholdPhone__c</field>
+        <field>Account.%%%NAMESPACE%%%HouseholdPhone__c</field>
     </columns>
     <description>Accounts that donated some year, but unfortunately not this year (SYBUNT)</description>
     <filter>
         <criteriaItems>
-            <column>Account.TotalOppAmount__c</column>
+            <column>Account.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Accounts_by_Best_Gift_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Accounts_by_Best_Gift_Year.report-meta.xml
@@ -11,7 +11,7 @@
         <chartType>VerticalColumn</chartType>
         <enableHoverLabels>false</enableHoverLabels>
         <expandOthers>true</expandOthers>
-        <groupingColumn>Account.Best_Gift_Year__c</groupingColumn>
+        <groupingColumn>Account.%%%NAMESPACE%%%Best_Gift_Year__c</groupingColumn>
         <location>CHART_TOP</location>
         <showAxisLabels>true</showAxisLabels>
         <showPercentage>false</showPercentage>
@@ -35,11 +35,11 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.Best_Gift_Year_Total__c</field>
+        <field>Account.%%%NAMESPACE%%%Best_Gift_Year_Total__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -50,7 +50,7 @@
     <description>All Accounts grouped by their highest giving year</description>
     <filter>
         <criteriaItems>
-            <column>Account.TotalOppAmount__c</column>
+            <column>Account.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
@@ -60,7 +60,7 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Day</dateGranularity>
-        <field>Account.Best_Gift_Year__c</field>
+        <field>Account.%%%NAMESPACE%%%Best_Gift_Year__c</field>
         <sortOrder>Desc</sortOrder>
     </groupingsDown>
     <name>Accounts by Best Gift Year</name>
@@ -71,7 +71,7 @@
     <reportType>AccountList</reportType>
     <scope>organization</scope>
     <showDetails>true</showDetails>
-    <sortColumn>Account.Best_Gift_Year_Total__c</sortColumn>
+    <sortColumn>Account.%%%NAMESPACE%%%Best_Gift_Year_Total__c</sortColumn>
     <sortOrder>Desc</sortOrder>
     <timeFrameFilter>
         <dateColumn>CREATED_DATE</dateColumn>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Closed_Won_Opps_Household.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Closed_Won_Opps_Household.report-meta.xml
@@ -28,7 +28,7 @@
     <description>All Closed/Won Opportunities grouped by giving Household Account</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value></value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Contact_LYBUNT2.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Contact_LYBUNT2.report-meta.xml
@@ -12,15 +12,15 @@
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
-        <field>Contact.OppAmountLastYear__c</field>
+        <field>Contact.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
-        <field>Contact.TotalOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Contact.AverageAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
         <field>ADDRESS2_CITY</field>
@@ -37,13 +37,13 @@
     <description>Contacts who donated last year, but unfortunately not this year (LYBUNT)</description>
     <filter>
         <criteriaItems>
-            <column>Contact.OppAmountLastYear__c</column>
+            <column>Contact.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Contact.OppAmountThisYear__c</column>
+            <column>Contact.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Contact_SYBUNT2.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Contact_SYBUNT2.report-meta.xml
@@ -12,15 +12,15 @@
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
-        <field>Contact.TotalOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
-        <field>Contact.AverageAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
-        <field>Contact.OppAmountLastYear__c</field>
+        <field>Contact.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <field>ADDRESS2_CITY</field>
@@ -37,13 +37,13 @@
     <description>Contacts who donated some year, but unfortunately not this year (SYBUNT)</description>
     <filter>
         <criteriaItems>
-            <column>Contact.TotalOppAmount__c</column>
+            <column>Contact.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Contact.OppAmountThisYear__c</column>
+            <column>Contact.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Contacts_by_Best_Gift_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Contacts_by_Best_Gift_Year.report-meta.xml
@@ -11,7 +11,7 @@
         <chartType>VerticalColumn</chartType>
         <enableHoverLabels>false</enableHoverLabels>
         <expandOthers>true</expandOthers>
-        <groupingColumn>Contact.Best_Gift_Year__c</groupingColumn>
+        <groupingColumn>Contact.%%%NAMESPACE%%%Best_Gift_Year__c</groupingColumn>
         <location>CHART_TOP</location>
         <showAxisLabels>true</showAxisLabels>
         <showPercentage>false</showPercentage>
@@ -35,11 +35,11 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Contact.Best_Gift_Year_Total__c</field>
+        <field>Contact.%%%NAMESPACE%%%Best_Gift_Year_Total__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Contact.TotalOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
         <field>ADDRESS2_CITY</field>
@@ -56,7 +56,7 @@
     <description>All Contacts grouped by their highest giving year</description>
     <filter>
         <criteriaItems>
-            <column>Contact.TotalOppAmount__c</column>
+            <column>Contact.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
@@ -66,7 +66,7 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Day</dateGranularity>
-        <field>Contact.Best_Gift_Year__c</field>
+        <field>Contact.%%%NAMESPACE%%%Best_Gift_Year__c</field>
         <sortOrder>Desc</sortOrder>
     </groupingsDown>
     <name>Contacts by Best Gift Year</name>
@@ -77,7 +77,7 @@
     <reportType>ContactList</reportType>
     <scope>organization</scope>
     <showDetails>true</showDetails>
-    <sortColumn>Contact.Best_Gift_Year_Total__c</sortColumn>
+    <sortColumn>Contact.%%%NAMESPACE%%%Best_Gift_Year_Total__c</sortColumn>
     <sortOrder>Desc</sortOrder>
     <timeFrameFilter>
         <dateColumn>CREATED_DATE</dateColumn>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Contacts_with_Giving_Totals.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Contacts_with_Giving_Totals.report-meta.xml
@@ -14,60 +14,60 @@
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.TotalOppAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.AverageAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%AverageAmount__c</field>
     </columns>
     <columns>
-        <field>Contact.Best_Gift_Year__c</field>
+        <field>Contact.%%%NAMESPACE%%%Best_Gift_Year__c</field>
     </columns>
     <columns>
-        <field>Contact.LastCloseDate__c</field>
+        <field>Contact.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <columns>
-        <field>Contact.FirstCloseDate__c</field>
-    </columns>
-    <columns>
-        <aggregateTypes>Average</aggregateTypes>
-        <aggregateTypes>Maximum</aggregateTypes>
-        <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.LargestAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%FirstCloseDate__c</field>
     </columns>
     <columns>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.SmallestAmount__c</field>
+        <field>Contact.%%%NAMESPACE%%%LargestAmount__c</field>
+    </columns>
+    <columns>
+        <aggregateTypes>Average</aggregateTypes>
+        <aggregateTypes>Maximum</aggregateTypes>
+        <aggregateTypes>Minimum</aggregateTypes>
+        <field>Contact.%%%NAMESPACE%%%SmallestAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.OppAmountThisYear__c</field>
+        <field>Contact.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.OppAmountLastYear__c</field>
+        <field>Contact.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.NumberOfClosedOpps__c</field>
+        <field>Contact.%%%NAMESPACE%%%NumberOfClosedOpps__c</field>
     </columns>
     <description>Provides summary calculations for Total Gifts, Best Gift Year, Largest Gifts, and more</description>
     <filter>
         <criteriaItems>
-            <column>Contact.TotalOppAmount__c</column>
+            <column>Contact.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Contacts_with_Soft_Credits.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Contacts_with_Soft_Credits.report-meta.xml
@@ -14,33 +14,33 @@
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.Soft_Credit_Total__c</field>
+        <field>Contact.%%%NAMESPACE%%%Soft_Credit_Total__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.Soft_Credit_This_Year__c</field>
+        <field>Contact.%%%NAMESPACE%%%Soft_Credit_This_Year__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.Soft_Credit_Last_Year__c</field>
+        <field>Contact.%%%NAMESPACE%%%Soft_Credit_Last_Year__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
         <aggregateTypes>Average</aggregateTypes>
         <aggregateTypes>Maximum</aggregateTypes>
         <aggregateTypes>Minimum</aggregateTypes>
-        <field>Contact.Soft_Credit_Two_Years_Ago__c</field>
+        <field>Contact.%%%NAMESPACE%%%Soft_Credit_Two_Years_Ago__c</field>
     </columns>
     <description>Provides summary calculations for Soft Credit Totals, Soft Credit This Year, Soft Credit Last Year, and Two Years Ago.</description>
     <filter>
         <criteriaItems>
-            <column>Contact.Soft_Credit_Total__c</column>
+            <column>Contact.%%%NAMESPACE%%%Soft_Credit_Total__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Donation_Change_This_Year_vs_Last_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Donation_Change_This_Year_vs_Last_Year.report-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Report xmlns="http://soap.sforce.com/2006/04/metadata">
     <aggregates>
-        <calculatedFormula>IF(Account.OppAmountLastYear__c:SUM=0, 1,(Account.OppAmountThisYear__c:SUM - Account.OppAmountLastYear__c:SUM) / Account.OppAmountLastYear__c:SUM)</calculatedFormula>
+        <calculatedFormula>IF(Account.%%%NAMESPACE%%%OppAmountLastYear__c:SUM=0, 1,(Account.%%%NAMESPACE%%%OppAmountThisYear__c:SUM - Account.%%%NAMESPACE%%%OppAmountLastYear__c:SUM) / Account.%%%NAMESPACE%%%OppAmountLastYear__c:SUM)</calculatedFormula>
         <datatype>percent</datatype>
         <developerName>FORMULA1</developerName>
         <isActive>true</isActive>
@@ -26,23 +26,23 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <description>Provides donation percentage change calculation between this year and the previous year, grouped by Account.</description>
     <filter>
         <booleanFilter>1 OR 2</booleanFilter>
         <criteriaItems>
-            <column>Account.OppAmountLastYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Expected_Opportunities.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Expected_Opportunities.report-meta.xml
@@ -7,7 +7,7 @@
         <chartSummaries>
             <aggregate>Sum</aggregate>
             <axisBinding>y</axisBinding>
-            <column>Opportunity.Amount_Outstanding__c</column>
+            <column>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</column>
         </chartSummaries>
         <chartType>Funnel</chartType>
         <enableHoverLabels>true</enableHoverLabels>
@@ -41,7 +41,7 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <description>Comprehensive list of Opportunities, grouped by Account Record Type, Opportunity Record Type, and Stage.</description>
     <filter>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Expected_Overdue_Payments.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Expected_Overdue_Payments.report-meta.xml
@@ -35,7 +35,7 @@
         <field>OppPayment__c.Payment_Method__c</field>
     </columns>
     <columns>
-        <field>Opportunity.Payments_Made__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Payments_Made__c</field>
     </columns>
     <columns>
         <field>CUST_CREATED_DATE</field>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Expected_Payments.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Expected_Payments.report-meta.xml
@@ -24,7 +24,7 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Grants_This_Year.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Grants_This_Year.report-meta.xml
@@ -34,10 +34,10 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <columns>
-        <field>Opportunity.Number_of_Payments__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Number_of_Payments__c</field>
     </columns>
     <columns>
         <field>Opportunity.%%%NAMESPACE%%%Is_Grant_Renewal__c</field>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Households_with_Giving_Totals.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Households_with_Giving_Totals.report-meta.xml
@@ -7,22 +7,22 @@
         <field>Account.One2OneContact__c</field>
     </columns>
     <columns>
-        <field>Account.LastCloseDate__c</field>
+        <field>Account.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <columns>
-        <field>Account.LastOppAmount__c</field>
-    </columns>
-    <columns>
-        <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%LastOppAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
+    </columns>
+    <columns>
+        <aggregateTypes>Sum</aggregateTypes>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
@@ -31,13 +31,13 @@
     <description>Provides summary calculations for Total Gifts, Best Gift Year, Largest Gifts, and more</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Household Account</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.TotalOppAmount__c</column>
+            <column>Account.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Lifetime_Account_Gift_Ranges.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Lifetime_Account_Gift_Ranges.report-meta.xml
@@ -5,7 +5,7 @@
         <developerName>BucketField_33954624</developerName>
         <masterLabel>Total Gift Range</masterLabel>
         <nullTreatment>z</nullTreatment>
-        <sourceColumnName>Account.TotalOppAmount__c</sourceColumnName>
+        <sourceColumnName>Account.%%%NAMESPACE%%%TotalOppAmount__c</sourceColumnName>
         <useOther>false</useOther>
         <values>
             <sourceValues>
@@ -42,18 +42,18 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
-        <field>Account.LastCloseDate__c</field>
+        <field>Account.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -64,7 +64,7 @@
     <description>Provides a breakdown of Total Gifts for all Accounts, grouped by gift range bucket.</description>
     <filter>
         <criteriaItems>
-            <column>Account.TotalOppAmount__c</column>
+            <column>Account.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Lifetime_Account_by_Level.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Lifetime_Account_by_Level.report-meta.xml
@@ -8,18 +8,18 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
-        <field>Account.LastCloseDate__c</field>
+        <field>Account.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_CITY</field>
@@ -30,7 +30,7 @@
     <description>Provides a breakdown of Total Gifts for all Accounts, grouped by Level.</description>
     <filter>
         <criteriaItems>
-            <column>Account.TotalOppAmount__c</column>
+            <column>Account.%%%NAMESPACE%%%TotalOppAmount__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
@@ -40,7 +40,7 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Day</dateGranularity>
-        <field>Account.Level__c</field>
+        <field>Account.%%%NAMESPACE%%%Level__c</field>
         <sortOrder>Asc</sortOrder>
     </groupingsDown>
     <name>Lifetime Account by Level</name>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Open_Opportunities.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Open_Opportunities.report-meta.xml
@@ -58,11 +58,11 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Payments_Made__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Payments_Made__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Opportunity.Amount_Outstanding__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Amount_Outstanding__c</field>
     </columns>
     <columns>
         <field>CLOSE_DATE</field>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Paid_Recurring_Donations.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Paid_Recurring_Donations.report-meta.xml
@@ -62,7 +62,7 @@
         <name>co</name>
         <value>1</value>
     </params>
-    <reportType>Opportunity@Opportunity.Recurring_Donation__c</reportType>
+    <reportType>Opportunity@Opportunity.%%%NAMESPACE%%%Recurring_Donation__c</reportType>
     <scope>organization</scope>
     <showDetails>true</showDetails>
     <timeFrameFilter>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Prior_Year_Giving_with_Mailing_Address.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Prior_Year_Giving_with_Mailing_Address.report-meta.xml
@@ -7,10 +7,10 @@
         <field>RECORDTYPE</field>
     </columns>
     <columns>
-        <field>Account.Formal_Greeting__c</field>
+        <field>Account.%%%NAMESPACE%%%Formal_Greeting__c</field>
     </columns>
     <columns>
-        <field>Account.Informal_Greeting__c</field>
+        <field>Account.%%%NAMESPACE%%%Informal_Greeting__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_STREET</field>
@@ -25,12 +25,12 @@
         <field>ADDRESS1_ZIP</field>
     </columns>
     <columns>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <description>List of Total Gift amounts with Household address information</description>
     <filter>
         <criteriaItems>
-            <column>Account.OppAmountLastYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/Top_25_Account_Donors_Lifetime.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/Top_25_Account_Donors_Lifetime.report-meta.xml
@@ -11,22 +11,22 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.TotalOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%TotalOppAmount__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.LastOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%LastOppAmount__c</field>
     </columns>
     <columns>
-        <field>Account.LastCloseDate__c</field>
+        <field>Account.%%%NAMESPACE%%%LastCloseDate__c</field>
     </columns>
     <description>List of 25 top Account donors, based on Total Gifts.</description>
     <format>Tabular</format>
@@ -39,7 +39,7 @@
     <rowLimit>25</rowLimit>
     <scope>organization</scope>
     <showDetails>true</showDetails>
-    <sortColumn>Account.TotalOppAmount__c</sortColumn>
+    <sortColumn>Account.%%%NAMESPACE%%%TotalOppAmount__c</sortColumn>
     <sortOrder>Desc</sortOrder>
     <timeFrameFilter>
         <dateColumn>CREATED_DATE</dateColumn>

--- a/force-app/main/default/reports/NPSP_Fundraising_Reports/X10_Increase_Projection.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Fundraising_Reports/X10_Increase_Projection.report-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Report xmlns="http://soap.sforce.com/2006/04/metadata">
     <aggregates>
-        <calculatedFormula>Account.OppAmountLastYear__c:SUM * 1.1</calculatedFormula>
+        <calculatedFormula>Account.%%%NAMESPACE%%%OppAmountLastYear__c:SUM * 1.1</calculatedFormula>
         <datatype>currency</datatype>
         <description>10 percent increase over the previous year giving</description>
         <developerName>FORMULA2</developerName>
@@ -11,7 +11,7 @@
         <scale>2</scale>
     </aggregates>
     <aggregates>
-        <calculatedFormula>Account.LastOppAmount__c:SUM * 1.1</calculatedFormula>
+        <calculatedFormula>Account.%%%NAMESPACE%%%LastOppAmount__c:SUM * 1.1</calculatedFormula>
         <datatype>currency</datatype>
         <developerName>FORMULA3</developerName>
         <isActive>true</isActive>
@@ -21,27 +21,27 @@
     </aggregates>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountThisYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountThisYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.OppAmountLastYear__c</field>
+        <field>Account.%%%NAMESPACE%%%OppAmountLastYear__c</field>
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.LastOppAmount__c</field>
+        <field>Account.%%%NAMESPACE%%%LastOppAmount__c</field>
     </columns>
     <description>Provides 10% increase projection figures over Last Gift and Last Year Total Gifts</description>
     <filter>
         <booleanFilter>1 OR 2</booleanFilter>
         <criteriaItems>
-            <column>Account.OppAmountLastYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountLastYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.OppAmountThisYear__c</column>
+            <column>Account.%%%NAMESPACE%%%OppAmountThisYear__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>greaterThan</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Health_Check/Empty_Household_Accounts.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Health_Check/Empty_Household_Accounts.report-meta.xml
@@ -4,13 +4,13 @@
         <field>ACCOUNT.NAME</field>
     </columns>
     <columns>
-        <field>Account.SYSTEM_AccountType__c</field>
+        <field>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</field>
     </columns>
     <columns>
         <field>TYPE</field>
     </columns>
     <columns>
-        <field>Account.Number_of_Household_Members__c</field>
+        <field>Account.%%%NAMESPACE%%%Number_of_Household_Members__c</field>
     </columns>
     <columns>
         <field>ADDRESS1_STREET</field>
@@ -33,13 +33,13 @@
     <description>Household Accounts with no members</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>Household Account</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Account.Number_of_Household_Members__c</column>
+            <column>Account.%%%NAMESPACE%%%Number_of_Household_Members__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>

--- a/force-app/main/default/reports/NPSP_Health_Check/Individual_Accounts_by_Account_Type.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Health_Check/Individual_Accounts_by_Account_Type.report-meta.xml
@@ -24,7 +24,7 @@
     <description>Lists Accounts grouped by their system Account Type.  Details are hidden to avoid data limits.  Check the group you want to see details on and click the Drill Down button.</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value/>
@@ -34,7 +34,7 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Day</dateGranularity>
-        <field>Account.SYSTEM_AccountType__c</field>
+        <field>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</field>
         <sortOrder>Asc</sortOrder>
     </groupingsDown>
     <name>Individual Accounts by Account Type</name>

--- a/force-app/main/default/reports/NPSP_Health_Check/Individual_Contacts_by_Account_Type.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Health_Check/Individual_Contacts_by_Account_Type.report-meta.xml
@@ -11,12 +11,12 @@
     </columns>
     <columns>
         <aggregateTypes>Sum</aggregateTypes>
-        <field>Account.SYSTEMIsIndividual__c</field>
+        <field>Account.%%%NAMESPACE%%%SYSTEMIsIndividual__c</field>
     </columns>
     <description>Lists Contacts grouped by their system Account Type.  Details are hidden to avoid data limits.  Check the group you want to see details on and click the Drill Down button.</description>
     <filter>
         <criteriaItems>
-            <column>Account.SYSTEM_AccountType__c</column>
+            <column>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>notEqual</operator>
             <value/>
@@ -27,8 +27,8 @@
     <groupingsDown>
         <aggregateType>Sum</aggregateType>
         <dateGranularity>Day</dateGranularity>
-        <field>Account.SYSTEM_AccountType__c</field>
-        <sortByName>Account.SYSTEMIsIndividual__c</sortByName>
+        <field>Account.%%%NAMESPACE%%%SYSTEM_AccountType__c</field>
+        <sortByName>Account.%%%NAMESPACE%%%SYSTEMIsIndividual__c</sortByName>
         <sortOrder>Asc</sortOrder>
         <sortType>Aggregate</sortType>
     </groupingsDown>

--- a/force-app/main/default/reports/NPSP_Health_Check/Opportunities_without_Payments.report-meta.xml
+++ b/force-app/main/default/reports/NPSP_Health_Check/Opportunities_without_Payments.report-meta.xml
@@ -25,13 +25,13 @@
         <field>CREATED_DATE</field>
     </columns>
     <columns>
-        <field>Opportunity.Number_of_Payments__c</field>
+        <field>Opportunity.%%%NAMESPACE%%%Number_of_Payments__c</field>
     </columns>
     <description>Opportunities that have no Payments.  You must add filter criteria for any Type or Recordtype Exclusions you have set in NPSP Settings.</description>
     <filter>
         <booleanFilter>1 AND 2 AND 3 AND (4 or 5)</booleanFilter>
         <criteriaItems>
-            <column>Opportunity.Number_of_Payments__c</column>
+            <column>Opportunity.%%%NAMESPACE%%%Number_of_Payments__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>
@@ -43,7 +43,7 @@
             <value>0</value>
         </criteriaItems>
         <criteriaItems>
-            <column>Opportunity.Do_Not_Automatically_Create_Payment__c</column>
+            <column>Opportunity.%%%NAMESPACE%%%Do_Not_Automatically_Create_Payment__c</column>
             <isUnlocked>false</isUnlocked>
             <operator>equals</operator>
             <value>0</value>

--- a/force-app/main/default/reports/Nonprofit_Edition_Reports/NPSP_Campaign_Household_Mailing_List_V2.report-meta.xml
+++ b/force-app/main/default/reports/Nonprofit_Edition_Reports/NPSP_Campaign_Household_Mailing_List_V2.report-meta.xml
@@ -28,13 +28,13 @@
         <field>ADDRESS2_COUNTRY</field>
     </columns>
     <columns>
-        <field>Contact.Formula_HouseholdMailingAddress__c</field>
+        <field>Contact.%%%NAMESPACE%%%Formula_HouseholdMailingAddress__c</field>
     </columns>
     <columns>
-        <field>Account.Formal_Greeting__c</field>
+        <field>Account.%%%NAMESPACE%%%Formal_Greeting__c</field>
     </columns>
     <columns>
-        <field>Account.Informal_Greeting__c</field>
+        <field>Account.%%%NAMESPACE%%%Informal_Greeting__c</field>
     </columns>
     <description>Lists addresses for a mailing campaign, avoiding household duplicates.
 Runs from a custom button on the Campaign record. Supports both the Classic and Lightning User Interface.</description>

--- a/scripts/add_namespace_tokens.sh
+++ b/scripts/add_namespace_tokens.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Script to add %%%NAMESPACE%%% tokens to custom field/object references
+# that don't already have them
+
+set -e
+
+FORCE_APP="/Users/laurameerkatz/Projects/carpathia/force-app/main/default"
+
+echo "=== Adding namespace tokens to metadata ==="
+
+# Function to add namespace tokens to a file
+# Patterns to handle:
+# 1. <field>CustomField__c</field> -> <field>%%%NAMESPACE%%%CustomField__c</field>
+# 2. Account.CustomField__c -> Account.%%%NAMESPACE%%%CustomField__c
+# 3. Contact.CustomField__c -> Contact.%%%NAMESPACE%%%CustomField__c
+# 4. Opportunity.CustomField__c -> Opportunity.%%%NAMESPACE%%%CustomField__c
+# 5. Campaign.CustomField__c -> Campaign.%%%NAMESPACE%%%CustomField__c
+# 6. CustomObject__c references in related lists, report types, etc.
+
+# Standard objects that need namespace tokens on their custom fields
+STANDARD_OBJECTS="Account|Contact|Opportunity|Campaign|Lead|Case|Task|Event|User"
+
+echo ""
+echo "--- Processing standard object layouts ---"
+# Process layouts for standard objects (Account, Contact, Opportunity, Campaign)
+for layout in "$FORCE_APP"/layouts/Account-*.layout-meta.xml \
+              "$FORCE_APP"/layouts/Contact-*.layout-meta.xml \
+              "$FORCE_APP"/layouts/Opportunity-*.layout-meta.xml \
+              "$FORCE_APP"/layouts/Campaign-*.layout-meta.xml; do
+    if [[ -f "$layout" ]]; then
+        # Add namespace token to <field>CustomField__c</field> patterns
+        # But skip if already has %%%NAMESPACE%%%
+        if grep -q '<field>[A-Za-z_]*__c</field>' "$layout" 2>/dev/null; then
+            echo "Processing fields: $(basename "$layout")"
+            # Replace <field>SomeField__c</field> with <field>%%%NAMESPACE%%%SomeField__c</field>
+            # Only if not already prefixed with %%%NAMESPACE%%%
+            sed -i '' -E 's/<field>([A-Za-z_]+__c)<\/field>/<field>%%%NAMESPACE%%%\1<\/field>/g' "$layout"
+        fi
+    fi
+done
+
+echo ""
+echo "--- Processing related lists in all layouts ---"
+# Process related lists in ALL layouts (custom object references)
+for layout in "$FORCE_APP"/layouts/*.layout-meta.xml; do
+    if [[ -f "$layout" ]]; then
+        # Add namespace token to <relatedList>CustomObject__c.CustomField__c</relatedList>
+        if grep -qE '<relatedList>[A-Za-z_]+__c\.[A-Za-z_]+__c</relatedList>' "$layout" 2>/dev/null; then
+            echo "Processing related lists: $(basename "$layout")"
+            # Replace CustomObject__c.CustomField__c with %%%NAMESPACE%%%CustomObject__c.%%%NAMESPACE%%%CustomField__c
+            sed -i '' -E 's/<relatedList>([A-Za-z_]+__c)\.([A-Za-z_]+__c)<\/relatedList>/<relatedList>%%%NAMESPACE%%%\1.%%%NAMESPACE%%%\2<\/relatedList>/g' "$layout"
+        fi
+        # Also handle standard object lookups like Opportunity.Previous_Grant_Opportunity__c
+        if grep -qE '<relatedList>(Account|Contact|Opportunity|Campaign)\.[A-Za-z_]+__c</relatedList>' "$layout" 2>/dev/null; then
+            echo "Processing standard object related lists: $(basename "$layout")"
+            sed -i '' -E 's/<relatedList>(Account|Contact|Opportunity|Campaign)\.([A-Za-z_]+__c)<\/relatedList>/<relatedList>\1.%%%NAMESPACE%%%\2<\/relatedList>/g' "$layout"
+        fi
+    fi
+done
+
+echo ""
+echo "--- Processing reports ---"
+# Process reports - add namespace to standard object field references
+for report in "$FORCE_APP"/reports/*/*.report-meta.xml; do
+    if [[ -f "$report" ]]; then
+        modified=false
+
+        # Check if file has patterns that need fixing
+        if grep -qE "(Account|Contact|Opportunity|Campaign)\.[A-Za-z_]+__c" "$report" 2>/dev/null; then
+            modified=true
+        fi
+
+        if [[ "$modified" == "true" ]]; then
+            echo "Processing: $(basename "$report")"
+            # Add namespace token after standard object prefix for custom fields
+            # Account.Field__c -> Account.%%%NAMESPACE%%%Field__c
+            sed -i '' -E 's/(Account|Contact|Opportunity|Campaign)\.([A-Za-z_]+__c)/\1.%%%NAMESPACE%%%\2/g' "$report"
+        fi
+    fi
+done
+
+echo ""
+echo "--- Processing validation rules ---"
+# Process validation rules
+for rule in "$FORCE_APP"/objects/*/validationRules/*.validationRule-meta.xml; do
+    if [[ -f "$rule" ]]; then
+        # Check for custom field references without namespace token
+        if grep -qE '\$[A-Za-z_]+\.[A-Za-z_]+__c' "$rule" 2>/dev/null || \
+           grep -qE 'ISCHANGED\([A-Za-z_]+__c\)' "$rule" 2>/dev/null; then
+            echo "Processing: $(basename "$rule")"
+            # Add namespace to field references in formulas like ISCHANGED(Field__c)
+            sed -i '' -E 's/ISCHANGED\(([A-Za-z_]+__c)\)/ISCHANGED(%%%NAMESPACE%%%\1)/g' "$rule"
+            sed -i '' -E 's/ISNEW\(([A-Za-z_]+__c)\)/ISNEW(%%%NAMESPACE%%%\1)/g' "$rule"
+            sed -i '' -E 's/ISBLANK\(([A-Za-z_]+__c)\)/ISBLANK(%%%NAMESPACE%%%\1)/g' "$rule"
+            sed -i '' -E 's/PRIORVALUE\(([A-Za-z_]+__c)\)/PRIORVALUE(%%%NAMESPACE%%%\1)/g' "$rule"
+            # Handle errorDisplayField
+            sed -i '' -E 's/<errorDisplayField>([A-Za-z_]+__c)<\/errorDisplayField>/<errorDisplayField>%%%NAMESPACE%%%\1<\/errorDisplayField>/g' "$rule"
+        fi
+    fi
+done
+
+echo ""
+echo "--- Processing flexipages ---"
+# Process flexipages
+for page in "$FORCE_APP"/flexipages/*.flexipage-meta.xml; do
+    if [[ -f "$page" ]]; then
+        if grep -qE 'Record\.[A-Za-z_]+__c' "$page" 2>/dev/null; then
+            echo "Processing: $(basename "$page")"
+            # Handle {!Record.Field__c} patterns
+            sed -i '' -E 's/Record\.([A-Za-z_]+__c)/Record.%%%NAMESPACE%%%\1/g' "$page"
+        fi
+    fi
+done
+
+echo ""
+echo "--- Processing formula fields on standard objects ---"
+# Process formula fields on standard objects (Account, Contact, Opportunity, Campaign)
+# Use Python for more precise formula parsing
+python3 << 'PYTHON_SCRIPT'
+import os
+import re
+import glob
+
+force_app = "/Users/laurameerkatz/Projects/carpathia/force-app/main/default"
+
+for obj in ["Account", "Contact", "Opportunity", "Campaign"]:
+    pattern = f"{force_app}/objects/{obj}/fields/*.field-meta.xml"
+    for filepath in glob.glob(pattern):
+        with open(filepath, 'r') as f:
+            content = f.read()
+
+        if '<formula>' not in content:
+            continue
+
+        # Extract formula content
+        formula_match = re.search(r'<formula>(.*?)</formula>', content, re.DOTALL)
+        if not formula_match:
+            continue
+
+        formula = formula_match.group(1)
+        original_formula = formula
+
+        # Add namespace tokens to custom field references in formula
+        # Pattern 1: $Setup.CustomSettings__c.Field__c
+        formula = re.sub(
+            r'\$Setup\.([A-Za-z_]+__c)\.([A-Za-z_]+__c)',
+            r'$Setup.%%%NAMESPACE%%%\1.%%%NAMESPACE%%%\2',
+            formula
+        )
+
+        # Pattern 2: Object.Field__c (standard object lookups)
+        formula = re.sub(
+            r'(Account|Contact|Opportunity|Campaign)\.([A-Za-z_]+__c)',
+            r'\1.%%%NAMESPACE%%%\2',
+            formula
+        )
+
+        # Pattern 3: Standalone field references - be more aggressive
+        # Match word boundary + field name ending in __c, not preceded by . or %
+        # This handles: (Field__c, ,Field__c, Field__c< Field__c> Field__c= etc
+        formula = re.sub(
+            r'(?<![.%A-Za-z_])([A-Za-z_]+__c)(?![A-Za-z_])',
+            r'%%%NAMESPACE%%%\1',
+            formula
+        )
+
+        if formula != original_formula:
+            print(f"Processing formula: {os.path.basename(filepath)}")
+            new_content = content.replace(f'<formula>{original_formula}</formula>',
+                                          f'<formula>{formula}</formula>')
+            with open(filepath, 'w') as f:
+                f.write(new_content)
+PYTHON_SCRIPT
+
+echo ""
+echo "--- Cleaning up double tokens ---"
+# Clean up any accidental double namespace tokens
+for file in "$FORCE_APP"/layouts/*.layout-meta.xml \
+            "$FORCE_APP"/reports/*/*.report-meta.xml \
+            "$FORCE_APP"/objects/*/validationRules/*.validationRule-meta.xml \
+            "$FORCE_APP"/flexipages/*.flexipage-meta.xml; do
+    if [[ -f "$file" ]]; then
+        if grep -q '%%%NAMESPACE%%%%%%NAMESPACE%%%' "$file" 2>/dev/null; then
+            echo "Fixing double tokens in: $(basename "$file")"
+            sed -i '' 's/%%%NAMESPACE%%%%%%NAMESPACE%%%/%%%NAMESPACE%%%/g' "$file"
+        fi
+    fi
+done
+
+echo ""
+echo "=== Done! ==="
+echo ""
+echo "Run 'cci flow run dev_org --org dev' to test the deployment."


### PR DESCRIPTION
# Changes

- Added %%%NAMESPACE%%% tokens to 94 metadata files that reference custom fields/objects on standard objects, enabling proper namespace handling for both managed and unmanaged deployments

**Examples of patterns fixed:**
- `<field>TotalOppAmount__c</field>` → `<field>%%%NAMESPACE%%%TotalOppAmount__c</field>`
- `Account.LastCloseDate__c` → `Account.%%%NAMESPACE%%%LastCloseDate__c`
- `<relatedList>Relationship__c.Contact__c</relatedList>` → `<relatedList>%%%NAMESPACE%%%Relationship__c.%%%NAMESPACE%%%Contact__c</relatedList>`
- `$Setup.Households_Settings__c.Field__c` → `$Setup.%%%NAMESPACE%%%Households_Settings__c.%%%NAMESPACE%%%Field__c`