### PR TITLE
Add MetaDeploy install plan for NPPatch Beta

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -349,3 +349,41 @@ orgs:
     scratch:
         build:
             config_file: orgs/build.json
+
+plans:
+     preview:
+        slug: beta
+        title: Install NPPatch Beta - Sandbox, Scratch Org, or Developer Edition Only 
+        tier: primary
+        is_listed: True
+        checks:
+            - when: "not tasks.check_my_domain_active()"
+              action: error
+              message: "Please enable My Domain in your org prior to installing."
+            - when: "not tasks.check_chatter_enabled()"
+              action: error
+              message: "NPPatch requires Chatter. Please enable Chatter in your org and try again."
+            - when: "'nppatch' in org_config.installed_packages"
+              action: error
+              message: "NPPatch is already installed in this org. This installer cannot be used with orgs that already have NPPatch."
+            - when: "tasks.check_advanced_currency_management()"
+              action: error
+              message: "Advanced Currency Management must be disabled to install NPPatch, but can be enabled after installation."
+            - when: "tasks.check_org_is_not_production()"                                                                                                               
+              action: error                                                                                                                                             
+              message: "NPPatch Beta cannot be installed in a production org. Please use a sandbox, scratch org, or Developer Edition."  
+        steps:
+            1:
+                task: update_dependencies
+            2:
+                task: deploy
+                options:
+                    path: unpackaged/pre/account_record_types
+                ui_options:
+                    name: Account Record Types
+            3:
+                task: ensure_record_type
+                ui_options:
+                    name: Opportunity Record Types
+            4:
+                task: install_managed_beta


### PR DESCRIPTION
# Changes

- Add `repo_url` to git config for MetaDeploy integration
- Add `preview` install plan with preflight checks:
  - My Domain enabled
  - Chatter enabled
  - NPPatch not already installed
  - Advanced Currency Management disabled
  - Not a production org (sandbox/scratch/DE only)
- Install steps: dependencies, account record types, opportunity record types, managed beta package