### PR TITLE
Add MetaDeploy install plan and preflight checks

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -11,6 +11,14 @@ project:
   source_format: sfdx
 
 tasks:
+  check_org_is_not_production:
+    description: Check if org is a sandbox, scratch org, or Developer Edition
+    class_path: cumulusci.tasks.preflight.settings.CheckSettingsValue
+    options:
+      settings_type: Organization
+      settings_field: IsSandbox
+      value: true
+
   robot:
     options:
       suites: robot/nppatch/tests


### PR DESCRIPTION
## Summary
- Add CumulusCI install plan (`plans.preview`) for MetaDeploy beta installer
- Define `check_org_is_not_production` preflight task to prevent beta installs in production orgs
- Fix `ensure_record_types` typo and missing `sobject` option
- Add GitHub repo URL to project config
- Style docs site to match nppatch.com branding

## Test plan
- [ ] Verify preflight checks pass on a scratch org / sandbox via install.nppatch.com
- [ ] Verify preflight blocks installation on a production org
- [ ] Confirm install plan completes successfully on a scratch org

🤖 Generated with [Claude Code](https://claude.com/claude-code)