### PR TITLE
Fix JSDoc @param type annotations for package install

### DIFF
--- a/force-app/nppatch-main/default/lwc/errRecordLog/errRecordLog.js
+++ b/force-app/nppatch-main/default/lwc/errRecordLog/errRecordLog.js
@@ -259,7 +259,7 @@ export default class errRecordLog extends NavigationMixin(LightningElement) {
 
     /***
     * @description Handles error construction and its display
-    * @param error: Error Event
+    * @param {*} error: Error Event
     */
     handleError(error) {
         this.error = (error && error.detail)

--- a/force-app/nppatch-main/default/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
+++ b/force-app/nppatch-main/default/lwc/geBatchGiftEntryTable/geBatchGiftEntryTable.js
@@ -357,10 +357,10 @@ export default class GeBatchGiftEntryTable extends LightningElement {
      *              properties to the object intended for use with url-type columns in
      *              lightning-datatables. One to be used as the url value and another
      *              to be used as its label.
-     * @param objectInfo objectInfo of the record object in context.
-     * @param urlSuffix value to be appended to the field name to comprise first new
+     * @param {*} objectInfo objectInfo of the record object in context.
+     * @param {*} urlSuffix value to be appended to the field name to comprise first new
      *        property name.
-     * @param urlLabelSuffix value to be appended to the field name to comprise second new
+     * @param {*} urlLabelSuffix value to be appended to the field name to comprise second new
      *        property name.
      * @returns {object}
      */

--- a/force-app/nppatch-main/default/lwc/geBatchWizard/geBatchWizard.js
+++ b/force-app/nppatch-main/default/lwc/geBatchWizard/geBatchWizard.js
@@ -496,7 +496,7 @@ export default class geBatchWizard extends NavigationMixin(LightningElement) {
     /***************************************************************************
      * @description Strips namespace prefix from the Data Import Batch donation matching
      * rule fields if in a namespaced context
-     * @param dataImportBatch
+     * @param {*} dataImportBatch
      * @returns {object}
      */
     stripNamespaceFromDonationMatchingRuleFields (dataImportBatch) {

--- a/force-app/nppatch-main/default/lwc/geFormRenderer/geFormRenderer.js
+++ b/force-app/nppatch-main/default/lwc/geFormRenderer/geFormRenderer.js
@@ -830,7 +830,7 @@ export default class GeFormRenderer extends LightningElement{
      * @description Add an error message to the overall page level error messages
      * array.
      *
-     * @param errorObject
+     * @param {*} errorObject
      */
     addPageLevelErrorMessage(errorObject) {
         errorObject.index = errorObject.index ? errorObject.index : 0;
@@ -1220,8 +1220,8 @@ export default class GeFormRenderer extends LightningElement{
 
     /**
      * validates donation donor type on sectionsList
-     * @param dataImportHelper
-     * @param sectionsList, list of sections
+     * @param {*} dataImportHelper
+     * @param {*} sectionsList, list of sections
      * @returns {boolean|*} - true if form invalid, false otherwise
      */
     isDonorTypeInvalid(dataImportHelper, sectionsList) {
@@ -1259,8 +1259,8 @@ export default class GeFormRenderer extends LightningElement{
 
     /**
      * Set donation donor error message using custom label depending on field presence
-     * @param dataImportHelper, Object - helper obj
-     * @param fieldWrapper, Array of fields with Values and Labels
+     * @param {*} dataImportHelper, Object - helper obj
+     * @param {*} fieldWrapper, Array of fields with Values and Labels
      * @returns {String}, formatted error message for donation donor validation
      */
     getDonationDonorErrorLabel(dataImportHelper) {
@@ -1305,9 +1305,9 @@ export default class GeFormRenderer extends LightningElement{
 
     /**
      * highlight geForm fields on lSections using sError as message
-     * @param dataImportHelper, Object - helper obj
-     * @param lSections, Array of geFormSection
-     * @param sError, String to set on setCustomValidity
+     * @param {*} dataImportHelper, Object - helper obj
+     * @param {*} lSections, Array of geFormSection
+     * @param {*} sError, String to set on setCustomValidity
      */
     highlightValidationErrorFields(dataImportHelper, lSections, sError) {
         const accountFields = [DONATION_DONOR_FIELDS.account1ImportedField, DONATION_DONOR_FIELDS.account1NameField];
@@ -1329,7 +1329,7 @@ export default class GeFormRenderer extends LightningElement{
 
     /**
      * helper object to minimize length of if statements and improve code legibility
-     * @param fieldWrapper, Array of fields with Values and Labels
+     * @param {*} fieldWrapper, Array of fields with Values and Labels
      * @returns Object, helper object to minimize length of if statements and improve code legibility
      */
     getDataImportHelper() {
@@ -1484,7 +1484,7 @@ export default class GeFormRenderer extends LightningElement{
 
     /**
      * Handle payment errors at the form level
-     * @param event The paymentError event object
+     * @param {*} event The paymentError event object
      */
     handleAsyncWidgetError(event) {
         let errorMessage = this.CUSTOM_LABELS.commonUnknownError;
@@ -1530,7 +1530,7 @@ export default class GeFormRenderer extends LightningElement{
 
     /**
      * @description Set variable that informs the form renderer when the widget is in a disabled state
-     * @param event
+     * @param {*} event
      */
     handleDisableElevateWidgetState (event) {
         this._isElevateWidgetInDisabledState = event.isElevateWidgetDisabled;
@@ -1647,7 +1647,7 @@ export default class GeFormRenderer extends LightningElement{
     /**
      * @description Function that prepares (sets batch defaults, remove credit card widget)
      * the gift entry form in Batch Mode
-     * @param templateSections
+     * @param {*} templateSections
      * @returns {sections}
      */
     prepareFormForBatchMode (templateSections) {
@@ -1683,8 +1683,8 @@ export default class GeFormRenderer extends LightningElement{
      * @description Retrieves a records mapped target field values and
      *              loads them into the appropriate source fields in use
      *              on the Gift Entry form.
-     * @param lookupFieldApiName Api name of the lookup field.
-     * @param selectedRecordId Id of the selected record.
+     * @param {*} lookupFieldApiName Api name of the lookup field.
+     * @param {*} selectedRecordId Id of the selected record.
      */
     loadSelectedRecordFieldValues(lookupFieldApiName, selectedRecordId) {
         let selectedRecordFields =
@@ -1914,8 +1914,8 @@ export default class GeFormRenderer extends LightningElement{
      *              Prevents one lookup from overwriting the reactive selectedRecordId
      *              and selectedRecordFields properties before getRecord has returned
      *              with data.
-     * @param selectedRecordId Id of record to be retrieved.
-     * @param selectedRecordFields Fields list to be retrieved.
+     * @param {*} selectedRecordId Id of record to be retrieved.
+     * @param {*} selectedRecordFields Fields list to be retrieved.
      */
     queueSelectedRecordForRetrieval(selectedRecordId, selectedRecordFields) {
         if (this.getSelectedRecordStatus === 'ready') {
@@ -2027,7 +2027,7 @@ export default class GeFormRenderer extends LightningElement{
     /*******************************************************************************
      * @description Updates the formState object that holds the current value
      * of all fields on the form.
-     * @param fields An object with key-value pairs.
+     * @param {*} fields An object with key-value pairs.
      */
     updateFormState(fields) {
         fields = this.removeFieldsNotUpdatableInFormState(fields);
@@ -2397,7 +2397,7 @@ export default class GeFormRenderer extends LightningElement{
     /**
      * @description Pass in a DataImport field's api to get that field's current
      * value from the formState object.
-     * @param fieldApiNameOrFieldReference: field name or an imported field reference object
+     * @param {*} fieldApiNameOrFieldReference: field name or an imported field reference object
      * @returns {*} Current value stored in formState for the passed-in field.
      */
     getFieldValueFromFormState(fieldApiNameOrFieldReference) {
@@ -2611,7 +2611,7 @@ export default class GeFormRenderer extends LightningElement{
      * @description Saves a Data Import record, makes an elevate payment if needed,
      * and processes the Data Import through BDI.
      *
-     * @param dataImportFromFormState
+     * @param {*} dataImportFromFormState
      */
     submitSingleGift = async () => {
         const gift = this.saveableFormState();

--- a/force-app/nppatch-main/default/lwc/geFormRenderer/geFormRendererHelper.js
+++ b/force-app/nppatch-main/default/lwc/geFormRenderer/geFormRendererHelper.js
@@ -5,7 +5,7 @@ import { isEmptyObject, isNotEmpty } from 'c/utilCommon';
  * @description Helper function used to convert an object that has key value pairs where
  * the value is an object with a value property, i.e. {value: {value:'', displayValue:''}},
  * into an object that has primitives as values: {value: ''}.
- * @param obj The object that has value objects.
+ * @param {*} obj The object that has value objects.
  * @returns An object that has primitives as values, derived from the "value" property of
  * the fields on the passed in object.
  */
@@ -25,7 +25,7 @@ export function flatten(obj) {
  * @description Helper function used to convert the additional object JSON format used by BDI to process
  * additional objects for a donation into a JSON format used by widgets. This widget JSON format is also stord in
  * the form renderer form state.
- * @param additionalObjectJson The additional object JSON string that needs to be converted to the widget format
+ * @param {*} additionalObjectJson The additional object JSON string that needs to be converted to the widget format
  * @return {string} The newly converted JSON string that can be used by widgets to read additional objects
  * applicable to the widget.
  */

--- a/force-app/nppatch-main/default/lwc/geFormSection/geFormSection.js
+++ b/force-app/nppatch-main/default/lwc/geFormSection/geFormSection.js
@@ -28,8 +28,8 @@ export default class GeFormSection extends LightningElement {
 
     /**
      * Sets custom validity on fields inside fieldsArray
-     * @param fieldsArray
-     * @param errorMessage
+     * @param {*} fieldsArray
+     * @param {*} errorMessage
      */
     @api
     setCustomValidityOnFields( fieldsArray, errorMessage ) {

--- a/force-app/nppatch-main/default/lwc/geFormService/geFormService.js
+++ b/force-app/nppatch-main/default/lwc/geFormService/geFormService.js
@@ -94,7 +94,7 @@ class GeFormService {
 
     /**
      * Get the type of lightning-input that should be used for a given field type.
-     * @param dataType  Data type of the field
+     * @param {*} dataType  Data type of the field
      * @returns {String}
      */
     getInputTypeFromDataType(dataType) {
@@ -103,7 +103,7 @@ class GeFormService {
 
     /**
      * Get the formatter for a lightning-input that should be used for a given field type
-     * @param dataType  Data type of the field
+     * @param {*} dataType  Data type of the field
      * @returns {String | undefined}
      */
     getNumberFormatterByDescribeType(dataType) {
@@ -112,7 +112,7 @@ class GeFormService {
 
     /**
      * Get a field info object by dev name from the render wrapper object
-     * @param fieldDevName  Dev name of the object to retrieve
+     * @param {*} fieldDevName  Dev name of the object to retrieve
      * @returns {BDI_FieldMapping}
      */
     getFieldMappingWrapper(fieldDevName) {
@@ -121,7 +121,7 @@ class GeFormService {
 
     /**
      * Get a field info object by dev name from the render wrapper object
-     * @param fieldDevName  Dev name of the object to retrieve
+     * @param {*} fieldDevName  Dev name of the object to retrieve
      * @returns {BDI_FieldMapping}
      */
     getFieldMappingWrapperFromTarget(targetFieldName) {
@@ -130,7 +130,7 @@ class GeFormService {
 
     /**
      * Get a object info object by dev name
-     * @param objectMappingDevName
+     * @param {*} objectMappingDevName
      * @returns {BDI_ObjectMapping}
      */
     getObjectMapping(objectMappingDevName) {

--- a/force-app/nppatch-main/default/lwc/geHome/geHome.js
+++ b/force-app/nppatch-main/default/lwc/geHome/geHome.js
@@ -100,9 +100,9 @@ export default class geHome extends NavigationMixin(LightningElement) {
     /*******************************************************************************
     * @description Method navigates to the provided View Name
     *
-    * @param viewName: String of View Name to navigate to
-    * @param formTemplateId: String of Template Id to Edit
-    * @param isClone: Boolean set to true if template should be cloned
+    * @param {*} viewName: String of View Name to navigate to
+    * @param {*} formTemplateId: String of Template Id to Edit
+    * @param {*} isClone: Boolean set to true if template should be cloned
     *
     */
     goToView(viewName, formTemplateId, isClone) {

--- a/force-app/nppatch-main/default/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
+++ b/force-app/nppatch-main/default/lwc/geTemplateBuilderFormFields/geTemplateBuilderFormFields.js
@@ -634,7 +634,7 @@ export default class geTemplateBuilderFormFields extends LightningElement {
 
     /**
      * Expand/collapse the header and all sub-sections for advanced form fields
-     * @param event
+     * @param {*} event
      */
     handleToggleAdvancedSection(event) {
         const collapsed = this.toggleExpandableSection(this.LOCATORS.ADVANCED_FIELDS_SECTION_ID);
@@ -647,7 +647,7 @@ export default class geTemplateBuilderFormFields extends LightningElement {
 
     /**
      * Expand/collapse the bundles section, no sub-sections currently present for this section
-     * @param event
+     * @param {*} event
      */
     handleToggleBundlesSection(event) {
         this.toggleExpandableSection(this.LOCATORS.FIELD_BUNDLES_SECTION_ID);
@@ -655,7 +655,7 @@ export default class geTemplateBuilderFormFields extends LightningElement {
 
     /**
      * Expand/collapse the header and all sub-section for basic form fields
-     * @param event
+     * @param {*} event
      */
     handleToggleBasicSection(event) {
         const collapsed = this.toggleExpandableSection(this.LOCATORS.FORM_FIELDS_SECTION_ID);
@@ -725,7 +725,7 @@ export default class geTemplateBuilderFormFields extends LightningElement {
 
     /**
      * Append help text to a field mapping, if it exists.
-     * @param fieldMapping
+     * @param {*} fieldMapping
      * @return {{helpText: *}|*}
      */
     mapFieldHelpText = (fieldMapping) => {

--- a/force-app/nppatch-main/default/lwc/geTemplateBuilderSectionModalBody/geTemplateBuilderSectionModalBody.js
+++ b/force-app/nppatch-main/default/lwc/geTemplateBuilderSectionModalBody/geTemplateBuilderSectionModalBody.js
@@ -116,7 +116,7 @@ export default class GeTemplateBuilderSectionModalBody extends LightningElement 
 
     /**
      * @description Sets the selected section display option
-     * @param event
+     * @param {*} event
      */
     handleDisplayOptionChange (event) {
         this._selectedDisplayMode = event.detail.value;

--- a/force-app/nppatch-main/default/lwc/gsApplicationStatus/gsApplicationStatus.js
+++ b/force-app/nppatch-main/default/lwc/gsApplicationStatus/gsApplicationStatus.js
@@ -131,8 +131,8 @@ export default class GsApplicationStatus extends LightningElement {
 
     /**
      * For accesibillity, if the user click on space, it calls the click method of the caller
-     * @param target the component that fired the event
-     * @param code key code  
+     * @param {*} target the component that fired the event
+     * @param {*} code key code  
      */
     handleKeypress({target, code}) {
         if (code === 'Space') {

--- a/force-app/nppatch-main/default/lwc/gsChecklistItem/gsChecklistItem.js
+++ b/force-app/nppatch-main/default/lwc/gsChecklistItem/gsChecklistItem.js
@@ -118,7 +118,7 @@ export default class GsChecklistItem extends NavigationMixin(LightningElement) {
     }
     /**
     * @description exec button action
-    * @param string button type
+    * @param {*} string button type
     */
     buttonAction(button) {
         switch (button.type) {
@@ -134,7 +134,7 @@ export default class GsChecklistItem extends NavigationMixin(LightningElement) {
     }
     /**
     * @description use NavigationMixin.GenerateUrl Api to navigate in SFDC org
-    * @param string button value
+    * @param {*} string button value
     */
     sfdcLinkAction(value) {
         const values = value.split(':');
@@ -148,7 +148,7 @@ export default class GsChecklistItem extends NavigationMixin(LightningElement) {
 
     /**
     * @description get attribute to navigate in sfdc pages
-    * @param string[] value arguments
+    * @param {*} string[] value arguments
     * @returns object
     */
     getSfdcLinkAttr(values) {
@@ -169,7 +169,7 @@ export default class GsChecklistItem extends NavigationMixin(LightningElement) {
 
     /**
     * @description Substitute 'c__' to package namespace
-    * @param string api name
+    * @param {*} string api name
     * @returns String
     */
     subNamespace(apiName) {
@@ -179,7 +179,7 @@ export default class GsChecklistItem extends NavigationMixin(LightningElement) {
     /**
      * Event when the user check or uncheck the checkbox in the item.
      * It calls the backend to update the status and call events to notify the front end to update the progress ring.
-     * @param event the event object.
+     * @param {*} event the event object.
      */
     onChange(event) {
         let checked = event.detail.checked;

--- a/force-app/nppatch-main/default/lwc/gsChecklistSetup/gsChecklistSetup.js
+++ b/force-app/nppatch-main/default/lwc/gsChecklistSetup/gsChecklistSetup.js
@@ -34,7 +34,7 @@ export default class gsChecklistSetup extends LightningElement {
 
     /**
     * @description This method getLabelValue all text info in the checklist section and his items
-    * @param ChecklistSection
+    * @param {*} ChecklistSection
     * @return ChecklistSection (getLabelValue)
     */
     getLabelValueSection = (section) => {
@@ -47,7 +47,7 @@ export default class gsChecklistSetup extends LightningElement {
 
     /**
     * @description This method getLabelValue all text info in checklist items
-    * @param ChecklistItem
+    * @param {*} ChecklistItem
     * @return ChecklistItem (getLabelValue)
     */
     getLabelValueItem = (item) => {

--- a/force-app/nppatch-main/default/lwc/gsLabelMapper/gsLabelMapper.js
+++ b/force-app/nppatch-main/default/lwc/gsLabelMapper/gsLabelMapper.js
@@ -313,7 +313,7 @@ const labelMap = {
 
 /**
 *  @description This function getLabelValue the string using labelMap for that
-*  @param string Name to label to getLabelValue
+*  @param {*} string Name to label to getLabelValue
 *  @return string
 */
 export default function getLabelValue(label) {

--- a/force-app/nppatch-main/default/lwc/progressRing/progressRing.js
+++ b/force-app/nppatch-main/default/lwc/progressRing/progressRing.js
@@ -24,7 +24,7 @@ export default class ProgressRing extends LightningElement {
 
     /***
     * @description Sets current progress value and determines the "d" parameter for the progress ring
-    * @param value Current progress value
+    * @param {*} value Current progress value
     */
     set valueNow(value) {
         this._valueNow = value === undefined || value === null ? 0 : value;
@@ -47,7 +47,7 @@ export default class ProgressRing extends LightningElement {
 
     /***
     * @description Sets progress status properties
-    * @param value Progress status: active, complete, warning, error, or any other value
+    * @param {*} value Progress status: active, complete, warning, error, or any other value
     */
     set status(value) {
         if (this.ringSize === undefined || this.ringSize === null) {

--- a/force-app/nppatch-main/default/lwc/rd2EditPaymentInformationModal/rd2EditPaymentInformationModal.js
+++ b/force-app/nppatch-main/default/lwc/rd2EditPaymentInformationModal/rd2EditPaymentInformationModal.js
@@ -151,7 +151,7 @@ export default class rd2EditPaymentInformationModal extends LightningElement {
 
     /**
      * @description Use updateRecord to update Recurring Donation
-     * @param fields all recurringDonation field values
+     * @param {*} fields all recurringDonation field values
      */
     updateRecurringDonation(fields) {
         const recordInput = { fields };
@@ -202,7 +202,7 @@ export default class rd2EditPaymentInformationModal extends LightningElement {
 
     /***
      * @description Handle component display when an error occurs
-     * @param isDisabled: Indicates if the Save button should be disabled
+     * @param {*} isDisabled: Indicates if the Save button should be disabled
      */
     setSaveButtonDisabled(isDisabled) {
         const disableBtn = !!(isDisabled && isDisabled === true);

--- a/force-app/nppatch-main/default/lwc/rd2EntryForm/rd2EntryForm.js
+++ b/force-app/nppatch-main/default/lwc/rd2EntryForm/rd2EntryForm.js
@@ -466,7 +466,7 @@ export default class rd2EntryForm extends LightningElement {
 
     /***
      * @description Checks if form re-rendering is required due to payment method change
-     * @param event Contains new payment method value
+     * @param {*} event Contains new payment method value
      */
     handlePaymentChange(event) {
         //reset the widget and the form related to the payment method
@@ -497,7 +497,7 @@ export default class rd2EntryForm extends LightningElement {
     /***
      * @description Handle schedule form fields:
      * - Recurring Type change might hide or display the credit card widget.
-     * @param event
+     * @param {*} event
      */
     handleRecurringTypeChange(event) {
         this.perform({
@@ -553,7 +553,7 @@ export default class rd2EntryForm extends LightningElement {
 
     /***
      * @description Currency change might hide or display the credit card widget
-     * @param event
+     * @param {*} event
      */
     handleCurrencyChange(event) {
         this.perform({
@@ -801,7 +801,7 @@ export default class rd2EntryForm extends LightningElement {
 
     /**
      * @description Handle a child-to-parent component error event
-     * @param event (error construct)
+     * @param {*} event (error construct)
      */
     handleChildComponentError(event) {
         const error = event.detail && event.detail.value ? event.detail.value : event.detail;

--- a/force-app/nppatch-main/default/lwc/rd2EntryFormScheduleSection/rd2EntryFormScheduleSection.js
+++ b/force-app/nppatch-main/default/lwc/rd2EntryFormScheduleSection/rd2EntryFormScheduleSection.js
@@ -260,7 +260,7 @@ export default class rd2EntryFormScheduleSection extends LightningElement {
 
     /**
      * @description Automatically Show/Hide the NumberOfPlannedInstallments field based on the Recurring Type value
-     * @param event
+     * @param {*} event
      */
     handleRecurringTypeChange(event) {
         const recurringType = event.target.value;
@@ -271,7 +271,7 @@ export default class rd2EntryFormScheduleSection extends LightningElement {
     /**
      * @description When the custom Recurring Period picklist is updated change what other fields are visible on the
      * page: Monthly - just day of month; Advanced: Show the full period picklist and other fields.
-     * @param event
+     * @param {*} event
      */
     handleRecurringPeriodChange(event) {
         const recurringPeriod = event.target.value;
@@ -281,7 +281,7 @@ export default class rd2EntryFormScheduleSection extends LightningElement {
     /**
      * @description When the Recurring Period picklist is Advanced, this picklist is visible and allows the User to select
      * any of the supported (and active) installment periods. If Monthly is selected, enable the DayOfMonth field visibility.
-     * @param event
+     * @param {*} event
      */
     handleAdvancedPeriodChange(event) {
         this.toggleLastDayFieldOnExperienceSite(event);
@@ -291,7 +291,7 @@ export default class rd2EntryFormScheduleSection extends LightningElement {
 
     /**
      * @description On Experience Sites, based on the Recurrent Donation data it will show/hide Last Date field.
-     * @param event
+     * @param {*} event
      */
     toggleLastDayFieldOnExperienceSite(event) {
         if(this.isExperienceSite) {
@@ -306,7 +306,7 @@ export default class rd2EntryFormScheduleSection extends LightningElement {
 
     /**
      * @description When the frequency changes, we need to check if the Annual Value changed
-     * @param event
+     * @param {*} event
      */
     handleRecurringFrequencyChange(event) {
         this.dispatchEvent(new CustomEvent("frequencychange", { detail: event.target.value }));
@@ -314,7 +314,7 @@ export default class rd2EntryFormScheduleSection extends LightningElement {
 
     /**
      * @description When the installments change, we need to check if the Annual Value changed
-     * @param event
+     * @param {*} event
      */
     handlePlannedInstallmentsChange(event) {
         this.dispatchEvent(new CustomEvent("installmentschange", { detail: event.target.value }));

--- a/force-app/nppatch-main/default/lwc/rd2PauseForm/rd2PauseForm.js
+++ b/force-app/nppatch-main/default/lwc/rd2PauseForm/rd2PauseForm.js
@@ -468,7 +468,7 @@ export default class Rd2PauseForm extends LightningElement {
 
     /***
     * @description Handle error
-    * @param error: Error Event
+    * @param {*} error: Error Event
     */
     handleError(error) {
         this.isLoading = false;
@@ -481,7 +481,7 @@ export default class Rd2PauseForm extends LightningElement {
 
     /***
     * @description Handle component display when an error occurs
-    * @param error: Error Event
+    * @param {*} error: Error Event
     */
     handleErrorDisplay() {
         const errorDetail = this.error.detail;

--- a/force-app/nppatch-main/default/lwc/util/util.js
+++ b/force-app/nppatch-main/default/lwc/util/util.js
@@ -229,11 +229,11 @@ const handleError = (error, fireShowToast = true, showToastMode, returnAsArray) 
 };
 
 /**
- * @param string       If replacements is an Array, reference replacements by index,
+ * @param {*} string       If replacements is an Array, reference replacements by index,
  *                     e.g. {0}, {1}, similar to Apex's String.format(...).
  *                     Else if replacements is an Object, reference replacements
  *                     via key, e.g. {firstName}.
- * @param replacements Typically, an Array or Object
+ * @param {*} replacements Typically, an Array or Object
  */
 const format = (string, replacements) => {
     let formattedString = isNull(string) ? "" : string;

--- a/force-app/nppatch-main/default/lwc/utilCommon/utilCommon.js
+++ b/force-app/nppatch-main/default/lwc/utilCommon/utilCommon.js
@@ -104,7 +104,7 @@ const isPrimative = (value) => {
 
 /**
  * Check if a value is undefined.
- * @param value         Value to check
+ * @param {*} value         Value to check
  * @returns {boolean}   TRUE when value is undefined.
  */
 const isUndefined = (value) => {
@@ -114,7 +114,7 @@ const isUndefined = (value) => {
 
 /**
  * Check if a primitive is undefined, null or blank string.
- * @param value         Value to check.
+ * @param {*} value         Value to check.
  * @returns {boolean}   TRUE when the given value is undefined, null or blank string.
  */
 const isEmpty = (value) => {
@@ -123,7 +123,7 @@ const isEmpty = (value) => {
 
 /**
  * Check if an object is empty
- * @param object         Object to check.
+ * @param {*} object         Object to check.
  * @returns {boolean}   TRUE when the given object is empty.
  */
 const isEmptyObject = (object) => {
@@ -135,7 +135,7 @@ const isEmptyObject = (object) => {
 
 /**
  * Inverse of isEmpty
- * @param value         Value to check.
+ * @param {*} value         Value to check.
  * @returns {boolean}   TRUE when the given value is not undefined, null or blank string.
  */
 const isNotEmpty = (value) => {
@@ -422,7 +422,7 @@ const getSubsetObject = (sourceObj, propertyNames) => {
 /**
  * @description Parses the api name string of a custom
  *              object or field and returns its namespace.
- * @param apiName
+ * @param {*} apiName
  * @returns {String} The namespace of the passed-in object or field.
  *              Null if the object or field does not have a namespace.
  */
@@ -534,8 +534,8 @@ const showToast = (title, message, variant, mode, messageData) => {
 
 /*******************************************************************************
  * @description Strips namespace prefix from object and field api names
- * @param apiName
- * @param namespacePrefix
+ * @param {*} apiName
+ * @param {*} namespacePrefix
  * @returns {*|string}
  */
 const stripNamespace = (apiName, namespacePrefix) => {
@@ -551,7 +551,7 @@ const stripNamespace = (apiName, namespacePrefix) => {
  * Useful when referencing the related record field on objects
  * in the lightning/uiRecordApi Record format:
  * https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_responses_record.htm
- * @param customFieldApiNameOrFieldReference
+ * @param {*} customFieldApiNameOrFieldReference
  * The ApiName of the relationship field for which the related record
  * field name is desired, or the field reference object.
  * https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_responses_field_value.htm#ui_api_responses_field_value
@@ -565,9 +565,9 @@ const relatedRecordFieldNameFor = (customFieldApiNameOrFieldReference) => {
 
 /**
  * @description Replaces the last instance of a string pattern with another pattern.
- * @param subject The original string.
- * @param toRemove The pattern for which the last instance should be removed.
- * @param replacement The pattern used to replace the last instance of toRemove.
+ * @param {*} subject The original string.
+ * @param {*} toRemove The pattern for which the last instance should be removed.
+ * @param {*} replacement The pattern used to replace the last instance of toRemove.
  * @returns {*|void|string} A new string with the last instance replaced.
  */
 const replaceLastInstanceOfWith = (subject, toRemove, replacement) => {

--- a/force-app/nppatch-main/default/lwc/utilNumberFormatter/utilNumberFormatter.js
+++ b/force-app/nppatch-main/default/lwc/utilNumberFormatter/utilNumberFormatter.js
@@ -40,7 +40,7 @@ const getNumberAsCurrencyByCode = (amount, currencyCode) => {
 * @description Formats the provided number into the lowest common denominator by currency as a string
 * based on the logged in user's locale and currency.
 *
-* @param number: Number to convert into lowest common denominator
+* @param {*} number: Number to convert into lowest common denominator
 */
 const getCurrencyLowestCommonDenominator = (number) => {
     let multiplier = isNull(currencyMultiplier.get(CURRENCY)) ? DEFAULT_MULTIPLIER : currencyMultiplier.get(CURRENCY);

--- a/force-app/nppatch-main/default/lwc/utilTemplateBuilder/utilTemplateBuilder.js
+++ b/force-app/nppatch-main/default/lwc/utilTemplateBuilder/utilTemplateBuilder.js
@@ -371,9 +371,9 @@ const generateId = () => {
 /*******************************************************************************
 * @description returns a list of target field names for the fields in the template
 * in the format objectName.fieldName
-* @param formTemplate: the form template
-* @param fieldMappings: the field mappings dev names
-* @param apiName: the sObject api name
+* @param {*} formTemplate: the form template
+* @param {*} fieldMappings: the field mappings dev names
+* @param {*} apiName: the sObject api name
 */
 const getRecordFieldNames = (formTemplate, fieldMappings, apiName) => {
     let fieldNames = [`${apiName}.Id`];
@@ -399,7 +399,7 @@ const getRecordFieldNames = (formTemplate, fieldMappings, apiName) => {
 
 /*******************************************************************************
 * @description this function will determine if a CRUD or FLS permission error page should display if a from   * template is returned with CRUD or FLS errors.
-* @param formTemplate: the form template
+* @param {*} formTemplate: the form template
 */
 const checkPermissionErrors = (formTemplate) => {
     let templateStr = JSON.stringify(formTemplate);
@@ -433,9 +433,9 @@ const checkPermissionErrors = (formTemplate) => {
 * @description returns a copy of the form template that has record values on the element
 * stored in the recordValue attribute
 * in the format objectName.fieldName
-* @param formTemplate: the form template
-* @param fieldMappings: the field mappings dev names
-* @param record: the contact or account record
+* @param {*} formTemplate: the form template
+* @param {*} fieldMappings: the field mappings dev names
+* @param {*} record: the contact or account record
 */
 const setRecordValuesOnTemplate = (templateSections, fieldMappings, record) => {
     // check if we have a contact or account record
@@ -506,7 +506,7 @@ const getPageAccess = async () => {
 /*******************************************************************************
 * @description Method adds a unique key to every item in a given collection.
 *
-* @param list: Some collection
+* @param {*} list: Some collection
 */
 const addKeyToCollectionItems = (list) => {
     return list.map(item => {


### PR DESCRIPTION
# Changes

- Add `{*}` type specifier to 89 JSDoc `@param` annotations across 23 LWC files that were missing type annotations
- Fixes `LWC1522: No type specified for @param` compile errors that caused beta package install failures
- May also resolve cascading install errors for `refundPayment` QuickAction and `rd2EntryForm` LWC1043

## Context

The API 63.0 LWC compiler enforces the `@param {Type} name description` format. Annotations like `@param event` without a type in braces are treated as compile errors during package install, blocking installation.

The install errors were:
1. `QuickAction(OppPayment__c.Refund)` — Not able to retrieve LWC bundle `nppatch:refundPayment`
2. `LWC1522: No type specified for @param "event"` in `rd2EntryForm`
3. `LWC1043: Event handler should be an expression` in `rd2EntryForm` (likely cascading from #2)

## Checklist

- [x] Tests pass locally
- [x] New behavior is covered by tests
- [x] No new PMD or ESLint violations introduced
- [x] Documentation updated if needed (README, docs/, inline comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)