### PR TITLE
Add post-install steps to beta plan

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -504,6 +504,12 @@ plans:
           path: unpackaged/pre/account_record_types
         ui_options:
           name: Account Record Types
+      2.1:
+        task: deploy
+        options:
+          path: unpackaged/pre/opportunity_record_types
+        ui_options:
+          name: Opportunity Record Types
       3:
         task: ensure_record_types
         options:
@@ -512,3 +518,26 @@ plans:
           name: Opportunity Record Types
       4:
         task: install_managed_beta
+      4.1:
+        task: ensure_record_types
+        options:
+          sobject: Account
+        ui_options:
+          name: Account Record Types
+      5:
+        task: deploy_post
+        options:
+          unmanaged: False
+        ui_options:
+          name: Account Layouts and Quick Actions
+      6:
+        task: default_settings
+        options:
+          managed: True
+          namespace_inject: $project_config.project__package__namespace
+        ui_options:
+          name: Default Settings
+      7:
+        task: update_admin_profile
+        ui_options:
+          name: Admin Profile Configuration


### PR DESCRIPTION
# Changes

- Add missing post-install configuration steps to the beta (MetaDeploy) installer plan
- Deploy opportunity record types pre-install (was missing, only account record types were deployed)
- Ensure Account record types are active after package install
- Deploy post-install metadata (Account compact layouts, list views, quick actions)
- Initialize default custom settings via anonymous Apex (TDTM triggers, rollup config, household naming, RD settings, scheduled jobs)
- Configure admin profile with correct page layout and record type assignments

## Context

The beta plan was only installing the package without any post-install configuration, leaving the org in a non-functional state. These steps mirror what `beta_org` and `ci_feature_2gp` flows already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)