### PR TITLE
Add Program Management Module to documentation

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -425,6 +425,137 @@ Reusable template for engagement plans.
 - Child Engagement_Plan_Task_Template__c records (task definitions)
 - Child Engagement_Plan__c records (instantiated plans)
 
+## Program Management
+
+NPPatch includes the Program Management Module (PMM), providing program and service delivery tracking alongside fundraising.
+
+### Program__c
+
+Represents a program offered by the organization.
+
+**Fields:**
+- `Name` - Program name
+- `Description__c` - Program description
+- `ShortSummary__c` - Brief summary
+- `StartDate__c` - Program start date
+- `EndDate__c` - Program end date
+- `ProgramIssueArea__c` - Issue area classification
+- `Status__c` - Active, Completed, Planned, etc.
+
+**Relationships:**
+- Child ProgramCohort__c records (cohorts within the program)
+- Child ProgramEngagement__c records (participant enrollments)
+- Child Service__c records (services offered under the program)
+
+### ProgramCohort__c
+
+Groups participants within a program for tracking and reporting.
+
+**Fields:**
+- `Name` - Cohort name
+- `Program__c` - Parent program
+- `Description__c` - Cohort details
+- `StartDate__c` - Cohort start date
+- `EndDate__c` - Cohort end date
+- `Status__c` - Active, Completed, Planned
+
+### ProgramEngagement__c
+
+Tracks a contact's participation in a program.
+
+**Fields:**
+- `Name` - Engagement name
+- `Contact__c` - Participating contact
+- `Account__c` - Related account
+- `Program__c` - Parent program
+- `ProgramCohort__c` - Assigned cohort
+- `Stage__c` - Enrollment stage (Applied, Enrolled, Active, Completed, Withdrawn)
+- `Role__c` - Participant's role (Client, Volunteer, Service Provider)
+- `ApplicationDate__c` - Date of application
+- `StartDate__c` - Engagement start date
+- `EndDate__c` - Engagement end date
+
+### Service__c
+
+A specific service offered under a program.
+
+**Fields:**
+- `Name` - Service name
+- `Program__c` - Parent program
+- `Description__c` - Service description
+- `Status__c` - Active, Inactive
+- `UnitOfMeasurement__c` - How service is measured (Hours, Sessions, Units)
+
+**Relationships:**
+- Child ServiceSchedule__c records
+- Child ServiceDelivery__c records
+
+### ServiceSchedule__c
+
+Defines a recurring schedule for delivering a service.
+
+**Fields:**
+- `Name` - Schedule name
+- `Service__c` - Parent service
+- `FirstSessionStart__c` - First session start date/time
+- `FirstSessionEnd__c` - First session end date/time
+- `Frequency__c` - How often sessions repeat (Daily, Weekly, Monthly)
+- `Interval__c` - Interval between sessions
+- `DaysOfWeek__c` - Which days sessions occur
+- `NumberOfServiceSessions__c` - Total sessions to generate
+- `ParticipantCapacity__c` - Maximum participants
+- `DefaultServiceQuantity__c` - Default quantity per delivery
+- `PrimaryServiceProvider__c` - Primary staff contact
+- `OtherServiceProvider__c` - Secondary staff contact
+
+### ServiceSession__c
+
+An individual occurrence of a scheduled service.
+
+**Fields:**
+- `Name` - Session name
+- `ServiceSchedule__c` - Parent schedule
+- `SessionStart__c` - Session start date/time
+- `SessionEnd__c` - Session end date/time
+- `Status__c` - Pending, Complete, Canceled
+- `PrimaryServiceProvider__c` - Staff delivering the session
+- `OtherServiceProvider__c` - Additional staff
+
+### ServiceParticipant__c
+
+Enrolls a contact in a service schedule.
+
+**Fields:**
+- `Name` - Participant name
+- `Contact__c` - Participating contact
+- `ProgramEngagement__c` - Related program engagement
+- `Service__c` - Parent service
+- `ServiceSchedule__c` - Enrolled schedule
+- `SignUpDate__c` - Date of enrollment
+- `Status__c` - Enrolled, Withdrawn, Completed
+
+### ServiceDelivery__c
+
+Records actual delivery of a service to a participant.
+
+**Fields:**
+- `Name` - Delivery name
+- `Contact__c` - Recipient contact
+- `Account__c` - Related account
+- `Service__c` - Service delivered
+- `ServiceSession__c` - Related session
+- `ProgramEngagement__c` - Related engagement
+- `Service_Provider__c` - Staff who delivered
+- `DeliveryDate__c` - Date of delivery
+- `Quantity__c` - Amount delivered
+- `AttendanceStatus__c` - Present, Absent, Excused
+- `AutonameOverride__c` - Custom name override
+
+**Features:**
+- Rollups to Contact, ProgramEngagement, Service, and ServiceSchedule
+- Batch rollup processing via `ServiceDeliveryRollupsBatch`
+- Trigger-driven updates via `ServiceDeliveryTriggerHandler`
+
 ## System Objects
 
 ### Error__c

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -97,26 +97,46 @@ NPPatch organizes code into functional modules, each with a two-letter or three-
 | **UTIL** | Utilities | Cross-cutting utility functions |
 | **USER** | User Management | User role and permission synchronization |
 
+### Program Management Modules
+
+The package also includes the Program Management Module (PMM), which uses a different naming convention — full words rather than short prefixes:
+
+| Prefix | Function Area | Purpose |
+|--------|--------------|---------|
+| **ServiceDelivery** | Service Delivery | Service delivery tracking, rollups, and trigger handling |
+| **ServiceSchedule** | Service Scheduling | Schedule creation, session generation, domain logic |
+| **ServiceSession** | Service Sessions | Session tracking, status management, attendance |
+| **ServiceParticipant** | Participants | Participant enrollment and trigger handling |
+| **ProgramEngagement** | Program Engagement | Participant engagement tracking and rollups |
+| **Program** | Programs | Program management and selection |
+| **Attendance** | Attendance | Attendance tracking UI and controller |
+
 ### Directory Organization
 
 ```
 force-app/
 ├── nppatch-common/         # Shared infrastructure (fflib, utilities)
-└── nppatch-main/
-    ├── Application.cls     # Central fflib application factory
-    ├── adapter/            # Adapter/Controller layer
-    ├── bdi/                # Batch Data Import classes
-    ├── default/
-    │   ├── classes/        # All Apex code, organized by module prefix
-    │   ├── objects/        # Custom objects and standard object extensions
-    │   ├── lwc/            # Lightning Web Components (~120)
-    │   ├── aura/           # Aura components (~46)
-    │   └── pages/          # Visualforce pages (payment wizard, utility pages)
-    ├── domain/             # Domain layer classes (_DOM)
-    ├── selector/           # Selector layer classes (_SEL)
-    ├── service/            # Service layer classes (_SVC)
-    ├── tdtm/               # TDTM trigger framework and handlers
-    └── test/               # Test utilities and factories
+├── nppatch-main/
+│   ├── Application.cls     # Central fflib application factory
+│   ├── adapter/            # Adapter/Controller layer
+│   ├── bdi/                # Batch Data Import classes
+│   ├── default/
+│   │   ├── classes/        # All Apex code, organized by module prefix
+│   │   ├── objects/        # Custom objects and standard object extensions
+│   │   ├── lwc/            # Lightning Web Components (~120)
+│   │   ├── aura/           # Aura components (~46)
+│   │   └── pages/          # Visualforce pages (payment wizard, utility pages)
+│   ├── domain/             # Domain layer classes (_DOM)
+│   ├── selector/           # Selector layer classes (_SEL)
+│   ├── service/            # Service layer classes (_SVC)
+│   ├── tdtm/               # TDTM trigger framework and handlers
+│   └── test/               # Test utilities and factories
+└── nppatch-prgm/           # Program Management Module (PMM)
+    └── default/
+        ├── classes/        # ~75 Apex classes (service delivery, scheduling, rollups)
+        ├── objects/        # 8 custom objects (Program, Service, ServiceDelivery, etc.)
+        ├── lwc/            # ~33 LWC components (attendance, scheduling, enrollment)
+        └── triggers/       # 2 triggers (ServiceDelivery, ServiceParticipant)
 ```
 
 ## Naming Conventions

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -18,7 +18,7 @@ NPPatch is a strong fit for organizations that meet some or all of these criteri
 
 Being fair about this: there are cases where Nonprofit Cloud is the right answer.
 
-**Organizations needing features beyond NPSP's scope.** Nonprofit Cloud includes program management, outcome tracking, case management, and other capabilities that NPSP was never designed to handle. If a client needs these, Nonprofit Cloud offers them as part of the platform.
+**Organizations needing features beyond NPSP's scope.** Nonprofit Cloud includes outcome tracking, case management, and other capabilities that NPSP was never designed to handle. NPPatch does include program management (via the Program Management Module), but if a client needs the broader Nonprofit Cloud platform capabilities, Nonprofit Cloud offers them.
 
 **Organizations that require vendor-backed support.** NPPatch is community-maintained. There is no Salesforce support contract, no guaranteed SLA, and no vendor standing behind the product. For organizations that need that level of support assurance, Nonprofit Cloud provides it.
 
@@ -68,7 +68,7 @@ Organizations that haven't modified the package code can upgrade normally. Organ
 When evaluating NPPatch for a client, consider:
 
 1. **Current state**: Is the client currently on NPSP? If so, how heavily customized is their implementation?
-2. **Feature requirements**: Does the client need capabilities that exist only in Nonprofit Cloud (program management, case management, outcome tracking)?
+2. **Feature requirements**: Does the client need capabilities that exist only in Nonprofit Cloud (case management, outcome tracking)? Note: NPPatch includes program management via PMM.
 3. **Support expectations**: Is the client comfortable with community-maintained software, or do they require vendor-backed support?
 4. **Technical capacity**: Does the client (or their consultant) have the technical skills to manage an unlocked package, apply upgrades, and troubleshoot issues?
 5. **Budget**: What are the comparative costs of Nonprofit Cloud licensing and implementation vs. NPPatch (which has no license cost but requires community or consultant support)?

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ NPPatch includes the full NPSP feature set, consolidated from the original five 
 - **Engagement Plans** — task-based engagement workflows triggered by donor activity
 - **Payment Management** — payment scheduling, tracking, and write-off support tied to opportunities
 - **Levels** — automated donor level assignment based on giving history
+- **Program Management** — program tracking, service scheduling, attendance recording, and service delivery measurement (based on the open-source Program Management Module)
 - **Error Logging** — centralized error capture and admin notification
 
 ## Technical Details at a Glance
@@ -56,10 +57,10 @@ NPPatch includes the full NPSP feature set, consolidated from the original five 
 | Salesforce API Version | 63.0 |
 | Build Tool | CumulusCI 4.6+ |
 | Architecture | Apex Enterprise Patterns (fflib) with TDTM trigger framework |
-| Custom Objects | 30+ |
+| Custom Objects | 38+ |
 | Custom Settings | 13 hierarchy + 8 list (21 total) |
-| Apex Classes | ~850 |
-| Lightning Web Components | ~120 |
+| Apex Classes | ~925 |
+| Lightning Web Components | ~155 |
 | Test Coverage Target | 75%+ |
 
 ## Getting Started
@@ -77,7 +78,7 @@ After installation, see [Post-Install Configuration](getting-started/post-instal
 
 NPPatch is built on the open-source code from the Salesforce.org Nonprofit Success Pack repositories. The original NPSP code was released under open-source licensing, and NPPatch follows those same license terms.
 
-The five original NPSP packages — TDTM (trigger framework), Contacts & Organizations, Households, Recurring Donations, and the main Nonprofit Success Pack — have been consolidated into a single repository and single package. The code, objects, and automation are functionally equivalent; what's changed is the packaging and distribution model.
+The five original NPSP packages — TDTM (trigger framework), Contacts & Organizations, Households, Recurring Donations, and the main Nonprofit Success Pack — plus the Program Management Module (PMM) have been consolidated into a single repository and single package. The code, objects, and automation are functionally equivalent; what's changed is the packaging and distribution model.
 
 !!! note "On Copyright and Documentation"
     All documentation in this project is original writing based on analysis of the open-source codebase. It describes what the code does, how it's structured, and how to work with it. This documentation is not derived from Salesforce's proprietary documentation.


### PR DESCRIPTION
# Changes

- Add PMM module prefixes and `nppatch-prgm/` directory to architecture overview
- Add 8 PMM custom objects (Program, Service, ServiceSchedule, ServiceSession, ServiceParticipant, ServiceDelivery, ProgramEngagement, ProgramCohort) to data model
- Add Program Management to feature list and update Apex/LWC/object counts in index
- Correct getting-started claims that program management is Nonprofit Cloud-only
- Plus earlier commits: reframe unlocked package messaging and address PR feedback on source visibility

---

## Checklist

- [x] Tests pass locally
- [x] No new PMD or ESLint violations introduced
- [x] Documentation updated if needed (README, docs/, inline comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)