### PR TITLE
Add nonprofit fundraising Opportunity stages via CCI task

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -112,6 +112,103 @@ tasks:
           closed: false
           won: false
 
+  add_fundraising_stages:
+    description: Add nonprofit fundraising Opportunity stages
+    class_path: cumulusci.tasks.metadata_etl.AddValueSetEntries
+    group: Metadata ETL
+    options:
+      api_names:
+        - OpportunityStage
+      entries:
+        # Donation stages
+        - fullName: Pledged
+          label: Pledged
+          probability: 50
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: Posted
+          label: Posted
+          probability: 100
+          forecastCategory: Closed
+          closed: true
+          won: true
+        - fullName: Withdrawn
+          label: Withdrawn
+          probability: 0
+          forecastCategory: Omitted
+          closed: true
+          won: false
+        # Grant stages
+        - fullName: LOI Submitted
+          label: LOI Submitted
+          probability: 10
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: Application Submitted
+          label: Application Submitted
+          probability: 25
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: Awarded
+          label: Awarded
+          probability: 90
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        # In-Kind stages
+        - fullName: Cultivating
+          label: Cultivating
+          probability: 10
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: In-Kind Not Yet Received
+          label: In-Kind Not Yet Received
+          probability: 50
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: In-Kind Received
+          label: In-Kind Received
+          probability: 100
+          forecastCategory: Closed
+          closed: true
+          won: true
+        # Major Gift stages
+        - fullName: Identification
+          label: Identification
+          probability: 10
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: Cultivation
+          label: Cultivation
+          probability: 20
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: Solicitation
+          label: Solicitation
+          probability: 50
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: Verbal Commitment
+          label: Verbal Commitment
+          probability: 90
+          forecastCategory: Pipeline
+          closed: false
+          won: false
+        - fullName: Declined
+          label: Declined
+          probability: 0
+          forecastCategory: Omitted
+          closed: true
+          won: false
+
   add_ocr_roles:
     description: Add OCR roles required by automated soft credit tests
     class_path: cumulusci.tasks.metadata_etl.AddValueSetEntries

--- a/unpackaged/config/dev/standardValueSets/OpportunityStage.standardValueSet
+++ b/unpackaged/config/dev/standardValueSets/OpportunityStage.standardValueSet
@@ -2,6 +2,33 @@
 <StandardValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <sorted>false</sorted>
     <standardValue>
+        <fullName>Cultivating</fullName>
+        <default>false</default>
+        <label>Cultivating</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>10</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>Identification</fullName>
+        <default>false</default>
+        <label>Identification</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>10</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>LOI Submitted</fullName>
+        <default>false</default>
+        <label>LOI Submitted</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>10</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
         <fullName>Prospecting</fullName>
         <default>false</default>
         <label>Prospecting</label>
@@ -20,12 +47,57 @@
         <won>false</won>
     </standardValue>
     <standardValue>
+        <fullName>Cultivation</fullName>
+        <default>false</default>
+        <label>Cultivation</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>20</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
         <fullName>Needs Analysis</fullName>
         <default>false</default>
         <label>Needs Analysis</label>
         <closed>false</closed>
         <forecastCategory>Pipeline</forecastCategory>
         <probability>20</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>Application Submitted</fullName>
+        <default>false</default>
+        <label>Application Submitted</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>25</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>In-Kind Not Yet Received</fullName>
+        <default>false</default>
+        <label>In-Kind Not Yet Received</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>50</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>Pledged</fullName>
+        <default>false</default>
+        <label>Pledged</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>50</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>Solicitation</fullName>
+        <default>false</default>
+        <label>Solicitation</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>50</probability>
         <won>false</won>
     </standardValue>
     <standardValue>
@@ -65,9 +137,27 @@
         <won>false</won>
     </standardValue>
     <standardValue>
+        <fullName>Awarded</fullName>
+        <default>false</default>
+        <label>Awarded</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>90</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
         <fullName>Negotiation/Review</fullName>
         <default>false</default>
         <label>Negotiation/Review</label>
+        <closed>false</closed>
+        <forecastCategory>Pipeline</forecastCategory>
+        <probability>90</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>Verbal Commitment</fullName>
+        <default>false</default>
+        <label>Verbal Commitment</label>
         <closed>false</closed>
         <forecastCategory>Pipeline</forecastCategory>
         <probability>90</probability>
@@ -83,6 +173,24 @@
         <won>true</won>
     </standardValue>
     <standardValue>
+        <fullName>In-Kind Received</fullName>
+        <default>false</default>
+        <label>In-Kind Received</label>
+        <closed>true</closed>
+        <forecastCategory>Closed</forecastCategory>
+        <probability>100</probability>
+        <won>true</won>
+    </standardValue>
+    <standardValue>
+        <fullName>Posted</fullName>
+        <default>false</default>
+        <label>Posted</label>
+        <closed>true</closed>
+        <forecastCategory>Closed</forecastCategory>
+        <probability>100</probability>
+        <won>true</won>
+    </standardValue>
+    <standardValue>
         <fullName>Closed Lost</fullName>
         <default>false</default>
         <label>Closed Lost</label>
@@ -92,11 +200,21 @@
         <won>false</won>
     </standardValue>
     <standardValue>
-        <fullName>Pledged</fullName>
+        <fullName>Declined</fullName>
         <default>false</default>
-        <label>Pledged</label>
-        <closed>false</closed>
+        <label>Declined</label>
+        <closed>true</closed>
         <forecastCategory>Omitted</forecastCategory>
+        <probability>0</probability>
+        <won>false</won>
+    </standardValue>
+    <standardValue>
+        <fullName>Withdrawn</fullName>
+        <default>false</default>
+        <label>Withdrawn</label>
+        <closed>true</closed>
+        <forecastCategory>Omitted</forecastCategory>
+        <probability>0</probability>
         <won>false</won>
     </standardValue>
 </StandardValueSet>


### PR DESCRIPTION
# Changes

Add a new `add_fundraising_stages` CCI task that additively inserts nonprofit-specific Opportunity stages using `AddValueSetEntries`. This covers stages for Donation, Grant, In-Kind, and Major Gift record types:

- **Donation:** Pledged, Posted, Withdrawn
- **Grant:** LOI Submitted, Application Submitted, Awarded
- **In-Kind:** Cultivating, In-Kind Not Yet Received, In-Kind Received
- **Major Gift:** Identification, Cultivation, Solicitation, Verbal Commitment, Declined

The dev config `OpportunityStage.standardValueSet` is also updated to include all new stages, ordered by probability with closed stages grouped at the end.

Per issue description, the goal was not override customer customisations; with that in mind, I did not make any changes to business processes.

# Issues Closed

Closes #20

---

## Checklist

- [x] Tests pass locally
- [ ] New behavior is covered by tests
- [x] No new PMD or ESLint violations introduced
- [ ] Documentation updated if needed (README, docs/, inline comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code) and subsequently edited by @leo-dcfa 